### PR TITLE
Load uhdm plugin before reading uhdm file

### DIFF
--- a/tests/1DUnpackedArray/yosys_script
+++ b/tests/1DUnpackedArray/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/1DUnpackedArray/yosys_script
+++ b/tests/1DUnpackedArray/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/2DFunctionArg/yosys_script
+++ b/tests/2DFunctionArg/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 hierarchy
 proc

--- a/tests/2DUnpackedArray/top.sv
+++ b/tests/2DUnpackedArray/top.sv
@@ -1,4 +1,4 @@
-module top(output o);
+module top(input clk, output o);
    logic a [1:0][2:0];
    assign a[1][2] = 1;
    assign o = a[1][2];

--- a/tests/2DUnpackedArray/yosys_script
+++ b/tests/2DUnpackedArray/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/2DUnpackedArray/yosys_script
+++ b/tests/2DUnpackedArray/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -clock clk -rstlen 10 -vcd dump.vcd

--- a/tests/2DUnpackedArray/yosys_script
+++ b/tests/2DUnpackedArray/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/AluOps/yosys_script
+++ b/tests/AluOps/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/AluOps/yosys_script
+++ b/tests/AluOps/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/AnonStructs/yosys_script
+++ b/tests/AnonStructs/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/AnonStructs/yosys_script
+++ b/tests/AnonStructs/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ArrayInit/yosys_script
+++ b/tests/ArrayInit/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 hierarchy
 proc

--- a/tests/AssignArraySelPlus/yosys_script
+++ b/tests/AssignArraySelPlus/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/AssignArraySelPlus/yosys_script
+++ b/tests/AssignArraySelPlus/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/AssignTypedefedFunctionCall/yosys_script
+++ b/tests/AssignTypedefedFunctionCall/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/AssignTypedefedFunctionCall/yosys_script
+++ b/tests/AssignTypedefedFunctionCall/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/AssignmentPattern/yosys_script
+++ b/tests/AssignmentPattern/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/AssignmentPattern/yosys_script
+++ b/tests/AssignmentPattern/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/AssignmentToConcatenation/yosys_script
+++ b/tests/AssignmentToConcatenation/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/AssignmentToConcatenation/yosys_script
+++ b/tests/AssignmentToConcatenation/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/BitsCallOnExpression/yosys_script
+++ b/tests/BitsCallOnExpression/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/BitsCallOnExpression/yosys_script
+++ b/tests/BitsCallOnExpression/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/BitsCallOnType/yosys_script
+++ b/tests/BitsCallOnType/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/BitsCallOnType/yosys_script
+++ b/tests/BitsCallOnType/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/BitsCallOnVar/yosys_script
+++ b/tests/BitsCallOnVar/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/BitsCallOnVar/yosys_script
+++ b/tests/BitsCallOnVar/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/CastExpression/yosys_script
+++ b/tests/CastExpression/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/CastExpression/yosys_script
+++ b/tests/CastExpression/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/CastLogic/top.sv
+++ b/tests/CastLogic/top.sv
@@ -1,3 +1,3 @@
-module top(output logic o);
+module top(input clk, output logic o);
    assign o = logic'(1);
 endmodule

--- a/tests/CastLogic/yosys_script
+++ b/tests/CastLogic/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/CastLogic/yosys_script
+++ b/tests/CastLogic/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -clock clk -rstlen 10 -vcd dump.vcd

--- a/tests/CastLogic/yosys_script
+++ b/tests/CastLogic/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/CastSize/yosys_script
+++ b/tests/CastSize/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/CastSize/yosys_script
+++ b/tests/CastSize/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/CastStruct/yosys_script
+++ b/tests/CastStruct/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/CastStruct/yosys_script
+++ b/tests/CastStruct/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/CastStructArray/yosys_script
+++ b/tests/CastStructArray/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/CastStructArray/yosys_script
+++ b/tests/CastStructArray/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/CastWidthFromPackage/yosys_script
+++ b/tests/CastWidthFromPackage/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/CastWidthFromPackage/yosys_script
+++ b/tests/CastWidthFromPackage/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/CellNamedLikeModule/yosys_script
+++ b/tests/CellNamedLikeModule/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/CellNamedLikeModule/yosys_script
+++ b/tests/CellNamedLikeModule/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/ConcatWidth/yosys_script
+++ b/tests/ConcatWidth/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ConcatWidth/yosys_script
+++ b/tests/ConcatWidth/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ConstSizes/yosys_script
+++ b/tests/ConstSizes/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/ConstSizes/yosys_script
+++ b/tests/ConstSizes/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/DeclarationInFor/yosys_script
+++ b/tests/DeclarationInFor/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/DeclarationInFor/yosys_script
+++ b/tests/DeclarationInFor/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/DpiChandle/yosys_script
+++ b/tests/DpiChandle/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/DpiChandle/yosys_script
+++ b/tests/DpiChandle/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/EmptyTask/yosys_script
+++ b/tests/EmptyTask/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/EmptyTask/yosys_script
+++ b/tests/EmptyTask/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/EmptyTask/yosys_script
+++ b/tests/EmptyTask/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/EnumConcat/yosys_script
+++ b/tests/EnumConcat/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/EnumConcat/yosys_script
+++ b/tests/EnumConcat/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/EnumConcatenatedConst/yosys_script
+++ b/tests/EnumConcatenatedConst/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/EnumConcatenatedConst/yosys_script
+++ b/tests/EnumConcatenatedConst/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/EnumConcatenatedConst/yosys_script
+++ b/tests/EnumConcatenatedConst/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/EnumInPackage/yosys_script
+++ b/tests/EnumInPackage/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/EnumInPackage/yosys_script
+++ b/tests/EnumInPackage/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/ExpressionInIndex/yosys_script
+++ b/tests/ExpressionInIndex/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ExpressionInIndex/yosys_script
+++ b/tests/ExpressionInIndex/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/Function2Returns/yosys_script
+++ b/tests/Function2Returns/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/Function2Returns/yosys_script
+++ b/tests/Function2Returns/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/Function2Returns/yosys_script
+++ b/tests/Function2Returns/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/FunctionColonReference/yosys_script
+++ b/tests/FunctionColonReference/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 hierarchy
 proc

--- a/tests/FunctionExportDPI/yosys_script
+++ b/tests/FunctionExportDPI/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/FunctionExportDPI/yosys_script
+++ b/tests/FunctionExportDPI/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/FunctionOutputArgument/yosys_script
+++ b/tests/FunctionOutputArgument/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/FunctionOutputArgument/yosys_script
+++ b/tests/FunctionOutputArgument/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/FunctionWithoutReturn/yosys_script
+++ b/tests/FunctionWithoutReturn/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/FunctionWithoutReturn/yosys_script
+++ b/tests/FunctionWithoutReturn/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/FunctionWithoutReturn/yosys_script
+++ b/tests/FunctionWithoutReturn/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/GenerateAssigns/yosys_script
+++ b/tests/GenerateAssigns/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/GenerateAssigns/yosys_script
+++ b/tests/GenerateAssigns/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/ImportFunction/yosys_script
+++ b/tests/ImportFunction/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ImportFunction/yosys_script
+++ b/tests/ImportFunction/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ImportPackageWithFunction/yosys_script
+++ b/tests/ImportPackageWithFunction/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ImportPackageWithFunction/yosys_script
+++ b/tests/ImportPackageWithFunction/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ImportedFunctionCallInModuleAndSubmodule/yosys_script
+++ b/tests/ImportedFunctionCallInModuleAndSubmodule/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ImportedFunctionCallInModuleAndSubmodule/yosys_script
+++ b/tests/ImportedFunctionCallInModuleAndSubmodule/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/IndexedPartSelect/yosys_script
+++ b/tests/IndexedPartSelect/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/IndexedPartSelect/yosys_script
+++ b/tests/IndexedPartSelect/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/IndexedPartSelectOfMember/yosys_script
+++ b/tests/IndexedPartSelectOfMember/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/IndexedPartSelectOfMember/yosys_script
+++ b/tests/IndexedPartSelectOfMember/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/LocalParamInNestedForLoops/yosys_script
+++ b/tests/LocalParamInNestedForLoops/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/LocalParamInNestedForLoops/yosys_script
+++ b/tests/LocalParamInNestedForLoops/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/LogicPackedArray/yosys_script
+++ b/tests/LogicPackedArray/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/LogicPackedArray/yosys_script
+++ b/tests/LogicPackedArray/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/MemoryPort/yosys_script
+++ b/tests/MemoryPort/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/MemoryPort/yosys_script
+++ b/tests/MemoryPort/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/MixedPatterns/yosys_script
+++ b/tests/MixedPatterns/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/MixedPatterns/yosys_script
+++ b/tests/MixedPatterns/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/MultipleAssignments/yosys_script
+++ b/tests/MultipleAssignments/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/MultipleAssignments/yosys_script
+++ b/tests/MultipleAssignments/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/MultipleCells/yosys_script
+++ b/tests/MultipleCells/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/MultipleCells/yosys_script
+++ b/tests/MultipleCells/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/MultipleNets/yosys_script
+++ b/tests/MultipleNets/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/MultipleNets/yosys_script
+++ b/tests/MultipleNets/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/MultiplePrints/yosys_script
+++ b/tests/MultiplePrints/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/MultiplePrints/yosys_script
+++ b/tests/MultiplePrints/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/NestedForLoops/yosys_script
+++ b/tests/NestedForLoops/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/NestedForLoops/yosys_script
+++ b/tests/NestedForLoops/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/OneAlwaysComb/yosys_script
+++ b/tests/OneAlwaysComb/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneAlwaysComb/yosys_script
+++ b/tests/OneAlwaysComb/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneAnd/yosys_script
+++ b/tests/OneAnd/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneAnd/yosys_script
+++ b/tests/OneAnd/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneArithShift/yosys_script
+++ b/tests/OneArithShift/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneArithShift/yosys_script
+++ b/tests/OneArithShift/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneCast/yosys_script
+++ b/tests/OneCast/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneCast/yosys_script
+++ b/tests/OneCast/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneConcat/yosys_script
+++ b/tests/OneConcat/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneConcat/yosys_script
+++ b/tests/OneConcat/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneDivider/yosys_script
+++ b/tests/OneDivider/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneDivider/yosys_script
+++ b/tests/OneDivider/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneFF/yosys_script
+++ b/tests/OneFF/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneFF/yosys_script
+++ b/tests/OneFF/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneImport/yosys_script
+++ b/tests/OneImport/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneImport/yosys_script
+++ b/tests/OneImport/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneInside/yosys_script
+++ b/tests/OneInside/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneInside/yosys_script
+++ b/tests/OneInside/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneNetInterf/yosys_script
+++ b/tests/OneNetInterf/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneNetInterf/yosys_script
+++ b/tests/OneNetInterf/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneNetModport/yosys_script
+++ b/tests/OneNetModport/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneNetModport/yosys_script
+++ b/tests/OneNetModport/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/OneNetRange/yosys_script
+++ b/tests/OneNetRange/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneNetRange/yosys_script
+++ b/tests/OneNetRange/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OnePackage/yosys_script
+++ b/tests/OnePackage/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OnePackage/yosys_script
+++ b/tests/OnePackage/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneReplicate/yosys_script
+++ b/tests/OneReplicate/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneReplicate/yosys_script
+++ b/tests/OneReplicate/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneShift/yosys_script
+++ b/tests/OneShift/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneShift/yosys_script
+++ b/tests/OneShift/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneStruct/yosys_script
+++ b/tests/OneStruct/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneStruct/yosys_script
+++ b/tests/OneStruct/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneSysFunc/yosys_script
+++ b/tests/OneSysFunc/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneSysFunc/yosys_script
+++ b/tests/OneSysFunc/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/OneThis/yosys_script
+++ b/tests/OneThis/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/OneThis/yosys_script
+++ b/tests/OneThis/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/PackageCast/dut.v
+++ b/tests/PackageCast/dut.v
@@ -2,6 +2,6 @@ package pkg;
    typedef enum logic[7:0] { ONE, TWO, THREE, FOUR, FIVE } enum_t;
 endpackage
 
-module dut(input logic[7:0] a, output pkg::enum_t b);
+module dut(input logic clk, input logic[7:0] a, output pkg::enum_t b);
    assign b = pkg::enum_t'(a);
 endmodule

--- a/tests/PackageCast/yosys_script
+++ b/tests/PackageCast/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/PackageCast/yosys_script
+++ b/tests/PackageCast/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/PackageCast/yosys_script
+++ b/tests/PackageCast/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug dut.uhdm
 prep -top \dut
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -clock clk -rstlen 10 -vcd dump.vcd

--- a/tests/PackedArray/yosys_script
+++ b/tests/PackedArray/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/PackedArray/yosys_script
+++ b/tests/PackedArray/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ParameterColonReference/yosys_script
+++ b/tests/ParameterColonReference/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 hierarchy
 proc

--- a/tests/ParameterConditionalAssignment/yosys_script
+++ b/tests/ParameterConditionalAssignment/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ParameterConditionalAssignment/yosys_script
+++ b/tests/ParameterConditionalAssignment/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ParameterPackedArray/yosys_script
+++ b/tests/ParameterPackedArray/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ParameterPackedArray/yosys_script
+++ b/tests/ParameterPackedArray/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ParameterPackedArraySurelogSubstitution/yosys_script
+++ b/tests/ParameterPackedArraySurelogSubstitution/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ParameterPackedArraySurelogSubstitution/yosys_script
+++ b/tests/ParameterPackedArraySurelogSubstitution/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ParameterSizeOfInstance/yosys_script
+++ b/tests/ParameterSizeOfInstance/yosys_script
@@ -3,4 +3,3 @@ read_uhdm -debug top.uhdm
 hierarchy
 proc
 opt
-sat -verify -seq 1 -tempinduct -prove-asserts -show-all

--- a/tests/ParameterSizeOfInstance/yosys_script
+++ b/tests/ParameterSizeOfInstance/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 hierarchy
 proc

--- a/tests/ParameterUnpackedArray/yosys_script
+++ b/tests/ParameterUnpackedArray/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ParameterUnpackedArray/yosys_script
+++ b/tests/ParameterUnpackedArray/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ParameterUnpackedLogicArray/yosys_script
+++ b/tests/ParameterUnpackedLogicArray/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ParameterUnpackedLogicArray/yosys_script
+++ b/tests/ParameterUnpackedLogicArray/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/PartSelect/yosys_script
+++ b/tests/PartSelect/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/PartSelect/yosys_script
+++ b/tests/PartSelect/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/PartSelectOfMember/yosys_script
+++ b/tests/PartSelectOfMember/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/PartSelectOfMember/yosys_script
+++ b/tests/PartSelectOfMember/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/PatternAsParameterOfInstance/yosys_script
+++ b/tests/PatternAsParameterOfInstance/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/PatternAsParameterOfInstance/yosys_script
+++ b/tests/PatternAsParameterOfInstance/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/PatternDefault/yosys_script
+++ b/tests/PatternDefault/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/PatternDefault/yosys_script
+++ b/tests/PatternDefault/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/PatternIndexes/yosys_script
+++ b/tests/PatternIndexes/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/PatternIndexes/yosys_script
+++ b/tests/PatternIndexes/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/PatternReplication/yosys_script
+++ b/tests/PatternReplication/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/PatternReplication/yosys_script
+++ b/tests/PatternReplication/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/PatternStruct/yosys_script
+++ b/tests/PatternStruct/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/PatternStruct/yosys_script
+++ b/tests/PatternStruct/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/PkgParamAsFunctionArg/yosys_script
+++ b/tests/PkgParamAsFunctionArg/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 hierarchy
 proc

--- a/tests/PutC/yosys_script
+++ b/tests/PutC/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/PutC/yosys_script
+++ b/tests/PutC/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/RealValue/yosys_script
+++ b/tests/RealValue/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/RealValue/yosys_script
+++ b/tests/RealValue/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ReturnFunctionCall/yosys_script
+++ b/tests/ReturnFunctionCall/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/ReturnFunctionCall/yosys_script
+++ b/tests/ReturnFunctionCall/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/ReturnFunctionCall/yosys_script
+++ b/tests/ReturnFunctionCall/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/SelectFromUnpackedInFunction/yosys_script
+++ b/tests/SelectFromUnpackedInFunction/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/SelectFromUnpackedInFunction/yosys_script
+++ b/tests/SelectFromUnpackedInFunction/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/StreamOp/yosys_script
+++ b/tests/StreamOp/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/StreamOp/yosys_script
+++ b/tests/StreamOp/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/StructInPackage/yosys_script
+++ b/tests/StructInPackage/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/StructInPackage/yosys_script
+++ b/tests/StructInPackage/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/StructMemberAsModuleInput/yosys_script
+++ b/tests/StructMemberAsModuleInput/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/StructMemberAsModuleInput/yosys_script
+++ b/tests/StructMemberAsModuleInput/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/StructMemberAsModuleInput/yosys_script
+++ b/tests/StructMemberAsModuleInput/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/StructParameter/yosys_script
+++ b/tests/StructParameter/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/StructParameter/yosys_script
+++ b/tests/StructParameter/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/SumOfParametersInNestedForLoops/yosys_script
+++ b/tests/SumOfParametersInNestedForLoops/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/SumOfParametersInNestedForLoops/yosys_script
+++ b/tests/SumOfParametersInNestedForLoops/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TaskExportDPI/yosys_script
+++ b/tests/TaskExportDPI/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TaskExportDPI/yosys_script
+++ b/tests/TaskExportDPI/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TaskImportDPI/yosys_script
+++ b/tests/TaskImportDPI/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TaskImportDPI/yosys_script
+++ b/tests/TaskImportDPI/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TaskOutputArgument/yosys_script
+++ b/tests/TaskOutputArgument/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TaskOutputArgument/yosys_script
+++ b/tests/TaskOutputArgument/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TaskOutputArgument/yosys_script
+++ b/tests/TaskOutputArgument/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/TaskReturn/yosys_script
+++ b/tests/TaskReturn/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TaskReturn/yosys_script
+++ b/tests/TaskReturn/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TaskReturn/yosys_script
+++ b/tests/TaskReturn/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/TypedefAlias/dut.v
+++ b/tests/TypedefAlias/dut.v
@@ -14,7 +14,7 @@ package pkg;
   typedef logic [7:0] third_alias_t;
 endpackage;
 
-module dut (input pkg::enum_t a, output pkg::alias_t b);
+module dut (input clk, input pkg::enum_t a, output pkg::alias_t b);
    typedef pkg::struct_t second_alias_t; // Can be moved to pkg after
                                          // https://github.com/chipsalliance/Surelog/issues/1388
 

--- a/tests/TypedefAlias/yosys_script
+++ b/tests/TypedefAlias/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefAlias/yosys_script
+++ b/tests/TypedefAlias/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/TypedefAlias/yosys_script
+++ b/tests/TypedefAlias/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug dut.uhdm
 prep -top \dut
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -clock clk -rstlen 10 -vcd dump.vcd

--- a/tests/TypedefAliasInPackage/yosys_script
+++ b/tests/TypedefAliasInPackage/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefAliasInPackage/yosys_script
+++ b/tests/TypedefAliasInPackage/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefEnum/top.sv
+++ b/tests/TypedefEnum/top.sv
@@ -1,10 +1,12 @@
 package pkg;
-   typedef enum logic {
-      x = 1
+   typedef enum logic[2:0] {
+      x = 1,
+      y = 2,
+      z = 3
    } a;
    typedef a b;
 endpackage
    
-module top(output pkg::b o);
+module top(input logic clk, output pkg::b o);
    assign o = pkg::x;
 endmodule   

--- a/tests/TypedefEnum/yosys_script
+++ b/tests/TypedefEnum/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefEnum/yosys_script
+++ b/tests/TypedefEnum/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -clock clk -rstlen 10 -vcd dump.vcd

--- a/tests/TypedefEnum/yosys_script
+++ b/tests/TypedefEnum/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefInModule/yosys_script
+++ b/tests/TypedefInModule/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefInModule/yosys_script
+++ b/tests/TypedefInModule/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefInModulePort/yosys_script
+++ b/tests/TypedefInModulePort/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefInModulePort/yosys_script
+++ b/tests/TypedefInModulePort/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefPackedDimensions/yosys_script
+++ b/tests/TypedefPackedDimensions/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefPackedDimensions/yosys_script
+++ b/tests/TypedefPackedDimensions/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefPackedDimensions/yosys_script
+++ b/tests/TypedefPackedDimensions/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/TypedefVariableDimensions/yosys_script
+++ b/tests/TypedefVariableDimensions/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefVariableDimensions/yosys_script
+++ b/tests/TypedefVariableDimensions/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefWithParameter/yosys_script
+++ b/tests/TypedefWithParameter/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefWithParameter/yosys_script
+++ b/tests/TypedefWithParameter/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefedFunctionArgument/yosys_script
+++ b/tests/TypedefedFunctionArgument/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefedFunctionArgument/yosys_script
+++ b/tests/TypedefedFunctionArgument/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefedFunctionReturn/yosys_script
+++ b/tests/TypedefedFunctionReturn/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefedFunctionReturn/yosys_script
+++ b/tests/TypedefedFunctionReturn/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefedRangedFunctionArgument/yosys_script
+++ b/tests/TypedefedRangedFunctionArgument/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefedRangedFunctionArgument/yosys_script
+++ b/tests/TypedefedRangedFunctionArgument/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/TypedefedRangedFunctionReturn/yosys_script
+++ b/tests/TypedefedRangedFunctionReturn/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/TypedefedRangedFunctionReturn/yosys_script
+++ b/tests/TypedefedRangedFunctionReturn/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/UnitForLoop/yosys_script
+++ b/tests/UnitForLoop/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 write_verilog
 write_verilog yosys.sv

--- a/tests/UnitForLoop/yosys_script
+++ b/tests/UnitForLoop/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/UnpackedArray/yosys_script
+++ b/tests/UnpackedArray/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/UnpackedArray/yosys_script
+++ b/tests/UnpackedArray/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/UnsizedConstant/yosys_script
+++ b/tests/UnsizedConstant/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/UnsizedConstant/yosys_script
+++ b/tests/UnsizedConstant/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/UnsizedConstantParameter/yosys_script
+++ b/tests/UnsizedConstantParameter/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/UnsizedConstantParameter/yosys_script
+++ b/tests/UnsizedConstantParameter/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/UnsizedConstantParameterInInstance/yosys_script
+++ b/tests/UnsizedConstantParameterInInstance/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/UnsizedConstantParameterInInstance/yosys_script
+++ b/tests/UnsizedConstantParameterInInstance/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/VarInFor/yosys_script
+++ b/tests/VarInFor/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/VarInFor/yosys_script
+++ b/tests/VarInFor/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/VarSelect/yosys_script
+++ b/tests/VarSelect/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/VarSelect/yosys_script
+++ b/tests/VarSelect/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/VoidFunction/yosys_script
+++ b/tests/VoidFunction/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/VoidFunction/yosys_script
+++ b/tests/VoidFunction/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/VoidFunction2Returns/yosys_script
+++ b/tests/VoidFunction2Returns/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/VoidFunction2Returns/yosys_script
+++ b/tests/VoidFunction2Returns/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/VoidFunctionWithoutReturn/yosys_script
+++ b/tests/VoidFunctionWithoutReturn/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/VoidFunctionWithoutReturn/yosys_script
+++ b/tests/VoidFunctionWithoutReturn/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/array-copy/yosys_script
+++ b/tests/array-copy/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 hierarchy
 proc

--- a/tests/assignment-pattern/yosys_script
+++ b/tests/assignment-pattern/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 hierarchy
 proc

--- a/tests/conditional_if/yosys_script
+++ b/tests/conditional_if/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 hierarchy -check -top \top

--- a/tests/conditional_if/yosys_script
+++ b/tests/conditional_if/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 hierarchy -check -top \top
 proc_clean
 proc_rmdead

--- a/tests/conditional_if_else/yosys_script
+++ b/tests/conditional_if_else/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 hierarchy -check -top \top

--- a/tests/conditional_if_else/yosys_script
+++ b/tests/conditional_if_else/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 hierarchy -check -top \top
 proc_clean
 proc_rmdead

--- a/tests/cs_registers/yosys_script
+++ b/tests/cs_registers/yosys_script
@@ -1,7 +1,6 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
 prep -top \dut
-write_json
 write_verilog
 write_verilog yosys.sv
 sat -verify -seq 100 -tempinduct -prove-asserts -show-all

--- a/tests/cs_registers/yosys_script
+++ b/tests/cs_registers/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 prep -top \dut
 write_json

--- a/tests/event_implicit_expression_list/yosys_script
+++ b/tests/event_implicit_expression_list/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/event_implicit_expression_list/yosys_script
+++ b/tests/event_implicit_expression_list/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/fsm_single_always/yosys_script
+++ b/tests/fsm_single_always/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug fsm_using_single_always.uhdm
-write_json
 prep -top \fsm_using_single_always
 write_verilog
 write_verilog yosys.sv

--- a/tests/fsm_single_always/yosys_script
+++ b/tests/fsm_single_always/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug fsm_using_single_always.uhdm
 write_json
 prep -top \fsm_using_single_always

--- a/tests/fsm_using_always/yosys_script
+++ b/tests/fsm_using_always/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug fsm_using_always.uhdm
 write_json
 prep -top \fsm_using_always

--- a/tests/fsm_using_always/yosys_script
+++ b/tests/fsm_using_always/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug fsm_using_always.uhdm
-write_json
 prep -top \fsm_using_always
 write_verilog
 write_verilog yosys.sv

--- a/tests/fsm_using_function/yosys_script
+++ b/tests/fsm_using_function/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug fsm_using_function.uhdm
 write_json
 prep -top \fsm_using_function

--- a/tests/fsm_using_function/yosys_script
+++ b/tests/fsm_using_function/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug fsm_using_function.uhdm
-write_json
 prep -top \fsm_using_function
 write_verilog
 write_verilog yosys.sv

--- a/tests/genscope_cells/yosys_script
+++ b/tests/genscope_cells/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 proc
 write_json

--- a/tests/genscope_cells/yosys_script
+++ b/tests/genscope_cells/yosys_script
@@ -1,7 +1,6 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
 proc
-write_json
 write_verilog
 write_verilog yosys.sv
 select -assert-count 1 \dut/gen_modules[1].module_in_genscope

--- a/tests/hier_path/yosys_script
+++ b/tests/hier_path/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug dut.uhdm
 write_json
 prep -top \dut

--- a/tests/hier_path/yosys_script
+++ b/tests/hier_path/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug dut.uhdm
-write_json
 prep -top \dut
 hierarchy; proc; opt
 write_verilog

--- a/tests/onenet/yosys_script
+++ b/tests/onenet/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/onenet/yosys_script
+++ b/tests/onenet/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/simple_unary_op_minus/yosys_script
+++ b/tests/simple_unary_op_minus/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/simple_unary_op_minus/yosys_script
+++ b/tests/simple_unary_op_minus/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/simple_unary_op_not_log/yosys_script
+++ b/tests/simple_unary_op_not_log/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/simple_unary_op_not_log/yosys_script
+++ b/tests/simple_unary_op_not_log/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/simple_unary_op_plus/yosys_script
+++ b/tests/simple_unary_op_plus/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/simple_unary_op_plus/yosys_script
+++ b/tests/simple_unary_op_plus/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/unary_op_minus/yosys_script
+++ b/tests/unary_op_minus/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/unary_op_minus/yosys_script
+++ b/tests/unary_op_minus/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/unary_op_not_log/yosys_script
+++ b/tests/unary_op_not_log/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/unary_op_not_log/yosys_script
+++ b/tests/unary_op_not_log/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/unary_op_plus/yosys_script
+++ b/tests/unary_op_plus/yosys_script
@@ -1,6 +1,5 @@
 plugin -i uhdm
 read_uhdm -debug top.uhdm
-write_json
 prep -top \top
 write_verilog
 write_verilog yosys.sv

--- a/tests/unary_op_plus/yosys_script
+++ b/tests/unary_op_plus/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 write_json
 prep -top \top

--- a/tests/xor_assignment/yosys_script
+++ b/tests/xor_assignment/yosys_script
@@ -1,3 +1,4 @@
+plugin -i uhdm
 read_uhdm -debug top.uhdm
 hierarchy
 proc


### PR DESCRIPTION
This change is required for yosys version that is using UHDM frontend as external plugin.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>