### PR TITLE
Change vlt rule to match new message

### DIFF
--- a/tests/opentitan/module_tests/prim_edn_req/prim_edn_req.vlt
+++ b/tests/opentitan/module_tests/prim_edn_req/prim_edn_req.vlt
@@ -2,6 +2,6 @@
 
 // Warnings that are thrown by original verilator
 
-lint_off -rule WIDTH -file "*" -match "Operator ASSIGNW expects 3 bits on the Assign RHS, but Assign RHS's DIVS generates 32 bits."
+lint_off -rule WIDTH -file "*" -match "Operator ASSIGNW expects 3 bits on the Assign RHS, but Assign RHS's DIVS generates 32 * bits."
 
-lint_off -rule WIDTH -file "*" -match "Operator ASSIGNW expects 1 bits on the Assign RHS, but Assign RHS's DIVS generates 32 bits."
+lint_off -rule WIDTH -file "*" -match "Operator ASSIGNW expects 1 bits on the Assign RHS, but Assign RHS's DIVS generates 32 * bits."

--- a/tests/opentitan/module_tests/prim_packer_fifo/prim_packer_fifo.vlt
+++ b/tests/opentitan/module_tests/prim_packer_fifo/prim_packer_fifo.vlt
@@ -2,4 +2,4 @@
 
 // Warnings that are thrown by original verilator
 
-lint_off -rule WIDTH -file "*" -match "Operator ASSIGNW expects 3 bits on the Assign RHS, but Assign RHS's DIVS generates 32 bits."
+lint_off -rule WIDTH -file "*" -match "Operator ASSIGNW expects 3 bits on the Assign RHS, but Assign RHS's DIVS generates 32 * bits."


### PR DESCRIPTION
The  warning messages have changed, because of parameters substitution. The new one is `Operator ASSIGNW expects 1 bits on the Assign RHS, but Assign RHS's DIVS generates 32 or 6 bits.`