### PR TITLE
Add test for don't care values in enum consts

### DIFF
--- a/tests/EnumConstX/Makefile.in
+++ b/tests/EnumConstX/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/EnumConstX/main.cpp
+++ b/tests/EnumConstX/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+      << " o: " << (top->o ? 1 : 0)
+      << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/EnumConstX/top.sv
+++ b/tests/EnumConstX/top.sv
@@ -1,0 +1,15 @@
+module top(input logic clk, output logic[3:0] o);
+   typedef enum logic [3:0] {
+        LMR      = 4'b0000,
+        REF      = 4'b0001,
+        PRE      = 4'b0010,
+        ACT      = 4'b0011,
+        WRITE    = 4'b0100,
+        READ     = 4'b0101,
+        BST      = 4'b0110,
+        NOP      = 4'b0111,
+        DESELECT = 4'b1xxx
+   } dfi_cmd_e;
+
+   assign o = DESELECT;
+endmodule

--- a/tests/EnumConstX/yosys_script
+++ b/tests/EnumConstX/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -clock clk -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
Test for `x` values in enum constants.

Related to Verilator change: https://github.com/antmicro/verilator/pull/498