### PR TITLE
Fix conditional_if test

### DIFF
--- a/tests/conditional_if/if.sv
+++ b/tests/conditional_if/if.sv
@@ -4,9 +4,9 @@
 :tags: 12.4
 */
 module top ();
-	wire a = 1;
-	reg b = 0;
-	always_latch @* begin
-		if(a) b = 1;
-	end
+    wire a = 1;
+    reg b = 0;
+    always_latch @* begin
+        if(a) b = 1;
+    end
 endmodule

--- a/tests/conditional_if/if.sv
+++ b/tests/conditional_if/if.sv
@@ -6,7 +6,7 @@
 module top ();
 	wire a = 1;
 	reg b = 0;
-	always @* begin
+	always_latch @* begin
 		if(a) b = 1;
 	end
 endmodule


### PR DESCRIPTION
Verilator generates a warning for this test if we use `always` instead of `always_latch` (as it should, see https://verilator.org/guide/latest/warnings.html#cmdoption-arg-LATCH)

Related PR: https://github.com/antmicro/verilator/pull/499