### PR TITLE
Add a cmake test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,12 @@ uhdm/verilator/test-ast: surelog/parse
 		 obj_dir/$(VERILATED_BIN))
 	mv $(root_dir)/build/dump.vcd $(root_dir)/dumps/dump_verilator.vcd
 
+uhdm/verilator/test-cmake: surelog/parse
+	(cd $(root_dir)/build && \
+		cmake -S ../$(TEST) -B . && \
+		make $(VERILATED_BIN) VERBOSE=1 && \
+		./$(VERILATED_BIN))
+
 uhdm/yosys/test-ast: surelog/parse
 	(cd $(root_dir)/build && ${YOSYS_BIN} -s $(YOSYS_SCRIPT))
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd uhdm-integration
 
 ## Running tests
 
-There are three main kinds of test cases:
+These are the main kinds of test cases:
 ### Surelog-UHDM-Verilator flow
 
 ```
@@ -62,6 +62,15 @@ make uhdm/vcddiff
 * Verilog output from Yosys is imported into Verilator and simulated.
 * Two VCD files from simulation (Surelog-UHDM-Verilator and Surelog-UHDM-Yosys-Verilator) are compared using `vcddiff` utility.
 
+### UHDM-Verilator cmake flow
+```
+make uhdm/verilator/test-cmake
+```
+
+This is the same flow as `uhdm/verilator/test-ast`, but makes use of Verilator's `cmake` functionality instead of default `make`. It allows bypassing some platform-specific quirks in Verilator makefiles and makes it easier to run tests on different platforms. Currently it is the only supported way to run tests on MacOS.
+
+Note that to run this flow the test needs to have a dedicated CMakeLists file. At this point only the ones in `tests/cmake` directory are supported.
+
 ## Test cases
 
 Available test cases are in the `tests` directory. They are chosen using `TEST_CASE` variable on make invocation, like so:
@@ -71,6 +80,9 @@ TEST=tests/OneNetModport make uhdm/verilator/test-ast
 Test results will be stored in `./build`.
 
 Tools are expected to be in `../images` folder. They can be built using `build_binaries.sh` found in Yosys/Verilator repository referenced in Setup.
+
+### Module tests
+`tests/ibex` and `tests/opentitan` contain special tests intended to test support for individual modules of [Ibex](https://github.com/lowRISC/ibex) and [OpenTitan](https://github.com/lowRISC/opentitan) designs. They make some assumptions regarding the location of the source files and so may need extra steps before running. Please refer to their makefiles for details.
 
 ## Integration details
 

--- a/tests/cmake/MultipleCells/CMakeLists.txt
+++ b/tests/cmake/MultipleCells/CMakeLists.txt
@@ -1,0 +1,97 @@
+cmake_minimum_required(VERSION 3.8)
+
+# Name of the project
+project(MultipleCells)
+
+# Verilog files to be verilated
+set(VTOP ${CMAKE_BINARY_DIR}/top.uhdm)
+list(APPEND VERILATOR_ARGS --uhdm-ast)
+
+# C/C++ source files to be compiled
+set(CSOURCES main.cpp)
+
+include(${CMAKE_BINARY_DIR}/../../verilator-config.cmake.in)
+set(USER_VERILATOR_DIR ${CMAKE_BINARY_DIR}/../../)
+
+set(COMP_LIB_ARGS -fPIC)
+
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
+# Hide not so usable variables from basic views of ccmake and cmake-gui
+mark_as_advanced(CMAKE_INSTALL_PREFIX verilator_DIR VERILATOR_ROOT VERILATOR_BIN PERL)
+
+if(IS_DIRECTORY "${USER_VERILATOR_DIR}" AND DEFINED ENV{VERILATOR_ROOT})
+  # Verilator CMake logic prioritizes VERILATOR_ROOT environment variable
+  message(STATUS "Using USER_VERILATOR_DIR over VERILATOR_ROOT env. var.")
+  set(ENV{VERILATOR_ROOT} ${USER_VERILATOR_DIR})
+endif()
+find_package(verilator HINTS ${USER_VERILATOR_DIR} $ENV{VERILATOR_ROOT})
+if(NOT verilator_FOUND)
+  set(USER_VERILATOR_DIR CACHE PATH "Path to the Verilator's root directory.")
+  message(FATAL_ERROR "There's no Verilator installed or its version is older than 4.022 (which introduced CMake support).\nEither install it or set the CMake's USER_VERILATOR_DIR variable to the Verilator's root directory.")
+endif()
+
+# Default arguments for compilation and linking
+list(APPEND PROJECT_COMP_ARGS -Wall)
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set(LIBOPENLIBM CACHE PATH "Absolute (!) path to the OpenLibm library (<RENODE_VERILATOR_INTEGRATION_PATH>/lib/libopenlibm-Linux-<TARGET_ARCH>.a). Use it for enhanced portability.")
+  # Link OpenLibm if LIBOPENLIBM is correctly set
+  if(LIBOPENLIBM)
+    if(EXISTS ${LIBOPENLIBM} AND IS_ABSOLUTE ${LIBOPENLIBM})
+      # `-Wl,--as-needed` in case it isn't passed to the linker by default
+      #   (e.g. Debian's g++ v8.3.0-6)
+      list(APPEND PROJECT_LINK_ARGS ${LIBOPENLIBM} -Wl,--as-needed)
+    else()
+      message(FATAL_ERROR "LIBOPENLIBM ('${LIBOPENLIBM}') has to be an absolute path!")
+    endif()
+  else()
+    message(WARNING "It is highly advised to use OpenLibm for portability reasons. To do so, run CMake with '-DLIBOPENLIBM=<REPOSITORY_ABSOLUTE_PATH>/lib/libopenlibm-Linux-<TARGET_ARCH>.a' or set LIBOPENLIBM variable through 'ccmake'/'cmake-gui'.")
+  endif()
+  if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    list(APPEND PROJECT_LINK_ARGS -static-libstdc++ -static-libgcc)
+  endif()
+endif()
+
+set(FINAL_EXEC_COMP_ARGS ${PROJECT_COMP_ARGS} ${COMP_EXEC_ARGS} CACHE STRING "Extra arguments/switches for compilation.")
+set(FINAL_LIB_COMP_ARGS ${PROJECT_COMP_ARGS} ${COMP_LIB_ARGS} CACHE STRING "Extra arguments/switches for compilation.")
+set(FINAL_EXEC_LINK_ARGS ${PROJECT_LINK_ARGS} ${LINK_EXEC_ARGS} CACHE STRING "Extra arguments/switches for linking.")
+set(FINAL_LIB_LINK_ARGS ${PROJECT_LINK_ARGS} ${LINK_LIB_ARGS} CACHE STRING "Extra arguments/switches for linking.")
+set(FINAL_EXEC_VERI_ARGS ${VERI_EXEC_ARGS}                      CACHE STRING "Extra arguments/switches for Verilating.")
+set(FINAL_LIB_VERI_ARGS ${VERI_LIB_ARGS}                      CACHE STRING "Extra arguments/switches for Verilating.")
+
+# The actual executable configuration
+
+if(NOT CSOURCES OR NOT VTOP)
+  message(FATAL_ERROR "Both 'CSOURCES' and 'VTOP' variables have to be set!")
+endif()
+
+add_executable(Vtop ${CSOURCES} ${RENODE_SOURCES})
+add_library(libVtop SHARED ${CSOURCES} ${RENODE_SOURCES})
+target_include_directories(Vtop PRIVATE ${VIL_DIR})
+target_include_directories(libVtop PRIVATE ${VIL_DIR})
+
+target_compile_options(Vtop PRIVATE ${FINAL_EXEC_COMP_ARGS})
+target_compile_options(libVtop PRIVATE ${FINAL_LIB_COMP_ARGS})
+target_link_libraries(Vtop PRIVATE ${FINAL_EXEC_LINK_ARGS})
+target_link_libraries(libVtop PRIVATE ${FINAL_LIB_LINK_ARGS})
+
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+  # Clang defaults to -std=gnu++98 but it has to be at least c++11
+  set_property(TARGET Vtop PROPERTY CXX_STANDARD 11)
+  set_property(TARGET libVtop PROPERTY CXX_STANDARD 11)
+  set_property(TARGET Vtop PROPERTY CXX_STANDARD_REQUIRED)
+  set_property(TARGET libVtop PROPERTY CXX_STANDARD_REQUIRED)
+
+  # Verilator for now only supports "clang", "gnu" and "msvc" in
+  # "--compiler" and creates it from CMAKE_CXX_COMPILER_ID
+  set(CMAKE_CXX_COMPILER_ID Clang)
+endif()
+set_target_properties(libVtop PROPERTIES OUTPUT_NAME Vtop)
+
+separate_arguments(FINAL_EXEC_VERI_ARGS)
+separate_arguments(FINAL_LIB_VERI_ARGS)
+verilate(Vtop SOURCES ${VTOP} VERILATOR_ARGS ${FINAL_EXEC_VERI_ARGS})
+

--- a/tests/cmake/MultipleCells/Makefile.in
+++ b/tests/cmake/MultipleCells/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/cmake/MultipleCells/main.cpp
+++ b/tests/cmake/MultipleCells/main.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#if TRACE
+#include <verilated_vcd_c.h>
+#endif
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+#if TRACE
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+#endif
+
+  top->i = 0;
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+#if TRACE
+    tfp->dump(main_time);
+#endif
+
+    main_time += 1;
+
+    if (!(main_time % 5)) {
+      top->i ^=1;
+    }
+
+    std::cout << "time: " << main_time
+      << " i: " << (top->i?1:0)
+      << " o1: " << (top->o1?1:0)
+      << " o2: " << (top->o2?1:0)
+      << std::endl;
+  }
+  top->final();
+#if TRACE
+  tfp->close();
+#endif
+    delete top;
+
+  return 0;
+}

--- a/tests/cmake/MultipleCells/top.sv
+++ b/tests/cmake/MultipleCells/top.sv
@@ -1,0 +1,11 @@
+module top (input wire i, output reg o1, output reg o2);
+   assigner #(.invert(0)) asgn0(.inp(i), .out(o1));
+   assigner #(.invert(1)) asgn1(.inp(i), .out(o2));
+endmodule
+
+module assigner #(parameter invert = 0) (input wire inp, output reg out);
+  if (!invert)
+    assign out = inp;
+  if (invert)
+    assign out = ~inp;
+endmodule


### PR DESCRIPTION
This PR adds a separate build target using CMake with Verilator in UHDM flow. It is needed to run the tests on macOS in CI.