### PR TITLE
Fix yosys_script

### DIFF
--- a/tests/TypedefVariableDimensions/yosys_script
+++ b/tests/TypedefVariableDimensions/yosys_script
@@ -3,4 +3,4 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -clock a -rstlen 10 -vcd dump.vcd
+sim -clock o -rstlen 10 -vcd dump.vcd

--- a/tests/UnsizedConstantsParameterParsing/yosys_script
+++ b/tests/UnsizedConstantsParameterParsing/yosys_script
@@ -3,4 +3,3 @@ read_uhdm -debug top.uhdm
 prep -top \top
 write_verilog
 write_verilog yosys.sv
-sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
This PR fixes yosys_script for ``TypedefVariableDimensions`` and ``UnsizedConstantsParameterParsing``.
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>