### PR TITLE
Add rule for replications in .vlt file

### DIFF
--- a/tests/opentitan/opentitan-210214/module_tests/prim_flash/prim_flash.vlt
+++ b/tests/opentitan/opentitan-210214/module_tests/prim_flash/prim_flash.vlt
@@ -31,3 +31,5 @@ lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the 
 lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h2' generates 128 bits."
 
 lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h3' generates 128 bits."
+
+lint_off -rule WIDTHCONCAT -file "*" -match "Unsized numbers/parameters not allowed in replications."

--- a/tests/opentitan/opentitan-210214/module_tests/prim_generic_flash/prim_generic_flash.vlt
+++ b/tests/opentitan/opentitan-210214/module_tests/prim_generic_flash/prim_generic_flash.vlt
@@ -31,3 +31,5 @@ lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the 
 lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h2' generates 128 bits."
 
 lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h3' generates 128 bits."
+
+lint_off -rule WIDTHCONCAT -file "*" -match "Unsized numbers/parameters not allowed in replications."


### PR DESCRIPTION
Original verilator throws the same warnings about concatenations.