### PR TITLE
Tests of expressions with constants that can be reduced

### DIFF
--- a/tests/AssignSumOfConstants/Makefile.in
+++ b/tests/AssignSumOfConstants/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/AssignSumOfConstants/main.cpp
+++ b/tests/AssignSumOfConstants/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " o: " << (int)top->o
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/AssignSumOfConstants/top.sv
+++ b/tests/AssignSumOfConstants/top.sv
@@ -1,0 +1,3 @@
+module top(output int o);
+   assign o = 1 + 2;
+endmodule

--- a/tests/AssignSumOfConstants/yosys_script
+++ b/tests/AssignSumOfConstants/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/AssignSumOfConstantsInSubmodule/Makefile.in
+++ b/tests/AssignSumOfConstantsInSubmodule/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/AssignSumOfConstantsInSubmodule/main.cpp
+++ b/tests/AssignSumOfConstantsInSubmodule/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " o: " << (int)top->o
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/AssignSumOfConstantsInSubmodule/top.sv
+++ b/tests/AssignSumOfConstantsInSubmodule/top.sv
@@ -1,0 +1,7 @@
+module submodule(output int a);
+   assign a = 1 + 2;
+endmodule
+
+module top(output int o);
+   submodule u_sub(.a(o));
+endmodule

--- a/tests/AssignSumOfConstantsInSubmodule/yosys_script
+++ b/tests/AssignSumOfConstantsInSubmodule/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/AssignSumWithParameter/Makefile.in
+++ b/tests/AssignSumWithParameter/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/AssignSumWithParameter/main.cpp
+++ b/tests/AssignSumWithParameter/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " o: " << (int)top->o
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/AssignSumWithParameter/top.sv
+++ b/tests/AssignSumWithParameter/top.sv
@@ -1,0 +1,4 @@
+module top(output int o);
+   parameter int P = 1;
+   assign o = P + 2;
+endmodule

--- a/tests/AssignSumWithParameter/yosys_script
+++ b/tests/AssignSumWithParameter/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/AssignSumWithParameterInSubmodule/Makefile.in
+++ b/tests/AssignSumWithParameterInSubmodule/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/AssignSumWithParameterInSubmodule/main.cpp
+++ b/tests/AssignSumWithParameterInSubmodule/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " o: " << (int)top->o
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/AssignSumWithParameterInSubmodule/top.sv
+++ b/tests/AssignSumWithParameterInSubmodule/top.sv
@@ -1,0 +1,8 @@
+module submodule(output int a);
+   parameter int P = 1;
+   assign a = P + 2;
+endmodule
+
+module top(output int o);
+   submodule u_sub(.a(o));
+endmodule

--- a/tests/AssignSumWithParameterInSubmodule/yosys_script
+++ b/tests/AssignSumWithParameterInSubmodule/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/CastToSumOfConstants/Makefile.in
+++ b/tests/CastToSumOfConstants/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/CastToSumOfConstants/main.cpp
+++ b/tests/CastToSumOfConstants/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " o: " << (int)top->o
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/CastToSumOfConstants/top.sv
+++ b/tests/CastToSumOfConstants/top.sv
@@ -1,0 +1,5 @@
+module top(output logic [2:0] o);
+   // We cast to the smaller width than the constant requires
+   // to see if the proper number of bits is taken
+   assign o = (1 + 2)'(31);
+endmodule

--- a/tests/CastToSumOfConstants/yosys_script
+++ b/tests/CastToSumOfConstants/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/CastToSumWithParameterInSubmodule/Makefile.in
+++ b/tests/CastToSumWithParameterInSubmodule/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/CastToSumWithParameterInSubmodule/main.cpp
+++ b/tests/CastToSumWithParameterInSubmodule/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " o: " << (int)top->o
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/CastToSumWithParameterInSubmodule/top.sv
+++ b/tests/CastToSumWithParameterInSubmodule/top.sv
@@ -1,0 +1,11 @@
+module submodule #(
+   parameter int P = 1
+) (
+   output logic [P + 1:0] a
+);
+   assign a = (P + 2)'(31);
+endmodule // submodule
+
+module top(output logic [2:0] o);
+   submodule #(.P(1)) u_sub (.a(o));
+endmodule // top

--- a/tests/CastToSumWithParameterInSubmodule/yosys_script
+++ b/tests/CastToSumWithParameterInSubmodule/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
Current Surelog sometimes substitute the whole expression with one constant. For example in CastToSumOfConstants and CastToSumWithParameterInSubmodule tests