### PR TITLE
Add CastToSumWithParameterIn2InstancesOfSubmodule test

### DIFF
--- a/tests/CastToSumWithParameterIn2InstancesOfSubmodule/Makefile.in
+++ b/tests/CastToSumWithParameterIn2InstancesOfSubmodule/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/CastToSumWithParameterIn2InstancesOfSubmodule/main.cpp
+++ b/tests/CastToSumWithParameterIn2InstancesOfSubmodule/main.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " o: " << (int)top->o
+              << " p: " << (int)top->p
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/CastToSumWithParameterIn2InstancesOfSubmodule/top.sv
+++ b/tests/CastToSumWithParameterIn2InstancesOfSubmodule/top.sv
@@ -1,0 +1,12 @@
+module submodule #(
+   parameter int P = 1
+) (
+   output logic [P + 1:0] a
+);
+   assign a = (P + 2)'(31);
+endmodule // submodule
+
+module top(output logic [2:0] o, output logic [4:0] p);
+   submodule #(.P(1)) u_sub1 (.a(o));
+   submodule #(.P(3)) u_sub3 (.a(p));
+endmodule // top

--- a/tests/CastToSumWithParameterIn2InstancesOfSubmodule/yosys_script
+++ b/tests/CastToSumWithParameterIn2InstancesOfSubmodule/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
This test is similar to the ones in https://github.com/chipsalliance/UHDM-integration-tests/pull/610.
It can't be passed with current Surelog, because the Surelog substitutes `(P + 2)` by constant `3`, even in uhdmAllModules section. The constant `3` is proper only in case of first instance. 