### PR TITLE
Add ParameterInitializedByOperationOnPackageParametersAndUsedInGenscope

### DIFF
--- a/tests/ParameterInitializedByOperationOnPackageParametersAndUsedInGenscope/Makefile.in
+++ b/tests/ParameterInitializedByOperationOnPackageParametersAndUsedInGenscope/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/ParameterInitializedByOperationOnPackageParametersAndUsedInGenscope/main.cpp
+++ b/tests/ParameterInitializedByOperationOnPackageParametersAndUsedInGenscope/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " o: " << (int)top->o
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/ParameterInitializedByOperationOnPackageParametersAndUsedInGenscope/top.sv
+++ b/tests/ParameterInitializedByOperationOnPackageParametersAndUsedInGenscope/top.sv
@@ -1,0 +1,16 @@
+package flash_phy_pkg;
+   parameter int DataWidth       = 64;
+   parameter int GfMultCycles  = 2;
+endpackage // flash_phy_pkg
+
+module top(output logic o);
+   import flash_phy_pkg::*;
+   localparam int Loops = DataWidth / GfMultCycles;
+   localparam int CntWidth = 1;
+
+   int x = 1;
+
+  if(1) begin : gen_decomposed
+    assign o = x == (Loops - 31);
+  end
+endmodule

--- a/tests/ParameterInitializedByOperationOnPackageParametersAndUsedInGenscope/yosys_script
+++ b/tests/ParameterInitializedByOperationOnPackageParametersAndUsedInGenscope/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
It is already passed.
I wanted to use it to reproduce warnings from https://github.com/chipsalliance/UHDM-integration-tests/pull/583, but these warnings are not the results of bugs. 