### PR TITLE
Add vlt rule about width of parameter init value

### DIFF
--- a/tests/opentitan/opentitan-210214/module_tests/prim_flash/prim_flash.vlt
+++ b/tests/opentitan/opentitan-210214/module_tests/prim_flash/prim_flash.vlt
@@ -33,3 +33,5 @@ lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the 
 lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h3' generates 128 bits."
 
 lint_off -rule WIDTHCONCAT -file "*" -match "Unsized numbers/parameters not allowed in replications."
+
+lint_off -rule WIDTH -file "*" -match "Operator VAR 'DataPartitionEndAddr' expects 8 bits on the Initial value, but Initial value's SUB generates 32 or 9 bits."

--- a/tests/opentitan/opentitan-210214/module_tests/prim_generic_flash/prim_generic_flash.vlt
+++ b/tests/opentitan/opentitan-210214/module_tests/prim_generic_flash/prim_generic_flash.vlt
@@ -33,3 +33,5 @@ lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the 
 lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h3' generates 128 bits."
 
 lint_off -rule WIDTHCONCAT -file "*" -match "Unsized numbers/parameters not allowed in replications."
+
+lint_off -rule WIDTH -file "*" -match "Operator VAR 'DataPartitionEndAddr' expects 8 bits on the Initial value, but Initial value's SUB generates 32 or 9 bits."


### PR DESCRIPTION
The warnings were because of parameter substitution. They started to occur in newest Surelog: https://github.com/antmicro/verilator/pull/647