### PR TITLE
Add ReplicationOfAssignmentPattern test

### DIFF
--- a/tests/ReplicationOfAssignmentPattern/Makefile.in
+++ b/tests/ReplicationOfAssignmentPattern/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/ReplicationOfAssignmentPattern/main.cpp
+++ b/tests/ReplicationOfAssignmentPattern/main.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " o: " << (int)top->o
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/ReplicationOfAssignmentPattern/top.sv
+++ b/tests/ReplicationOfAssignmentPattern/top.sv
@@ -1,0 +1,4 @@
+module top(output [5:0] o);
+   assign o = {3{'{1'b1,
+                   1'b0}}};
+endmodule // top

--- a/tests/ReplicationOfAssignmentPattern/yosys_script
+++ b/tests/ReplicationOfAssignmentPattern/yosys_script
@@ -1,0 +1,6 @@
+plugin -i uhdm
+read_uhdm -debug top.uhdm
+prep -top \top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
Because of parameter substitution, this test is similar to PatternReplicationPassedToPort test from https://github.com/chipsalliance/UHDM-integration-tests/pull/632.
The error is exactly the same:
```
%Error-UNSUPPORTED: /home/rrozak/Documents/verilator/uhdm-integration/tests/ReplicationOfAssignmentPattern//top.sv:3:18: Unsupported/Illegal: Assignment pattern member not underneath a supported construct: REPLICATE

%Error: Internal Error: /home/rrozak/Documents/verilator/uhdm-integration/tests/ReplicationOfAssignmentPattern//top.sv:3:15: ../V3Width.cpp:5387: Node has no type
```
But on this test, that error is thrown by original verilator too.
I will check if it is legal statement.