### PR TITLE
Update waivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ uhdm/verilator/get-ast: clean-build
 
 uhdm/verilator/ast-xml: surelog/parse
 	(cd $(root_dir)/build && \
-		$(VERILATOR_BIN) --uhdm-ast --cc $(TOP_UHDM) \
+		$(VERILATOR_BIN) --uhdm-ast-sv --cc $(TOP_UHDM) \
 			$(VERILATOR_FLAGS) \
 			--top-module ${TOP_MODULE} \
 			--dump-uhdm \

--- a/tests/opentitan/opentitan-210214/module_tests/prim_flash/prim_flash.vlt
+++ b/tests/opentitan/opentitan-210214/module_tests/prim_flash/prim_flash.vlt
@@ -26,11 +26,11 @@ lint_off -rule WIDTHCONCAT -file "*" -match "Unsized numbers/parameters not allo
 
 // Warnings that are thrown by uhdm-verilator
 
-lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h1' generates 128 bits."
+lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '64'h1' generates 64 bits."
 
-lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h2' generates 128 bits."
+lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '64'h2' generates 64 bits."
 
-lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h3' generates 128 bits."
+lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '64'h3' generates 64 bits."
 
 lint_off -rule WIDTHCONCAT -file "*" -match "Unsized numbers/parameters not allowed in replications."
 

--- a/tests/opentitan/opentitan-210214/module_tests/prim_generic_flash/prim_generic_flash.vlt
+++ b/tests/opentitan/opentitan-210214/module_tests/prim_generic_flash/prim_generic_flash.vlt
@@ -26,11 +26,11 @@ lint_off -rule WIDTHCONCAT -file "*" -match "Unsized numbers/parameters not allo
 
 // Warnings that are thrown by uhdm-verilator
 
-lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h1' generates 128 bits."
+lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '64'h1' generates 64 bits."
 
-lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h2' generates 128 bits."
+lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '64'h2' generates 64 bits."
 
-lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '128'h3' generates 128 bits."
+lint_off -rule WIDTH -file "*" -match "Operator PATMEMBER expects 9 bits on the Pattern value, but Pattern value's CONST '64'h3' generates 64 bits."
 
 lint_off -rule WIDTHCONCAT -file "*" -match "Unsized numbers/parameters not allowed in replications."
 


### PR DESCRIPTION
Update waivers for Opentitan modules to reflect current constant sizes in UHDM.