### PR TITLE
add more tests for decimal numbers

### DIFF
--- a/tests/ConstSizes/dut.v
+++ b/tests/ConstSizes/dut.v
@@ -1,6 +1,13 @@
-module dut (output logic[63:0] a, output logic[63:0] b, output logic[63:0] c, output logic[63:0] d);
+module dut (output logic[63:0] a, output logic[63:0] b, output logic[63:0] c, output logic[63:0] d,
+            output logic[63:0] e, output logic[63:0] f, output logic[63:0] g, output logic[63:0] h,
+            output logic[63:0] i);
    assign a = 64'd7698294523898761276;
    assign b = 7698294523898761276;
    assign c = 64'b1010110110110101001010101100101010101010101010101010101010101110;
    assign d = 64'hACBF74CFA4B5A09B;
+   assign e = 2147483528;
+   assign f = 4273735593;
+   assign g = 8547471186;
+   assign h = 4611686018427387904;
+   assign i = 18446612958979913719;
 endmodule


### PR DESCRIPTION
In response to https://github.com/chipsalliance/yosys-f4pga-plugins/pull/391#pullrequestreview-1159636179

I'm adding tests for decimal numbers of varied widths.
Please note that the PR mentioned above is supposed to handle decimals up to 64 bits, and numbers that exceed 64 bits shall be stored as strings in UHDM, which has recently been fixed in Surelog: https://github.com/chipsalliance/Surelog/issues/3293

CC @rkapuscik 