### PR TITLE
Add test for bitwise operations

### DIFF
--- a/tests/bitwise_operations/Makefile.in
+++ b/tests/bitwise_operations/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/bitwise_operations/main.cpp
+++ b/tests/bitwise_operations/main.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " out_1: " << (int)top->out_1
+              << " out_2: " << (int)top->out_2
+              << " out_3: " << (int)top->out_3
+              << " out_4: " << (int)top->out_4
+              << " out_5: " << (int)top->out_5
+              << " out_6: " << (int)top->out_6
+              << " out_7: " << (int)top->out_7
+              << " out_8: " << (int)top->out_8
+              << " out_9: " << (int)top->out_9
+              << " out_10: " << (int)top->out_10
+              << " out_11: " << (int)top->out_11
+              << " out_12: " << (int)top->out_12
+              << " out_13: " << (int)top->out_13
+              << " out_14: " << (int)top->out_14
+              << " out_15: " << (int)top->out_15
+              << " out_16: " << (int)top->out_16
+              << " out_17: " << (int)top->out_17
+              << " out_18: " << (int)top->out_18
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/bitwise_operations/top.sv
+++ b/tests/bitwise_operations/top.sv
@@ -1,0 +1,27 @@
+module top
+(
+    input [3:0] in,
+    output out_1, out_2, out_3, out_4, out_5, out_6, out_7, out_8, out_9, out_10,
+           out_11, out_12, out_13, out_14, out_15, out_16, out_17, out_18
+);
+    assign out_1 =  in[0] & in[1];
+    assign out_2 =  in[0] | in[1];
+    assign out_3 =  in[0] ~& in[1];
+    assign out_4 =  in[0] ~| in[1];
+    assign out_5 =  in[0] ^ in[1];
+    assign out_6 =  in[0] ~^ in[1];
+    assign out_7 =  in[0] ^~ in[1];
+    assign out_8 =  ~in[0];
+    assign out_9 =  in[0];
+    assign out_10 =  &in[0];
+    assign out_11 =  |in[0];
+    assign out_12 =  ~&in[0];
+    assign out_13 =  ~|in[0];
+    assign out_14 =  ^in[0];
+    assign out_15 =  ~^in[0];
+    assign out_16 =  ^~in[0];
+    assign out_17 =  in[0:1] && in [2:3];
+    assign out_18 =  in[0:1] || in [2:3];
+
+endmodule
+

--- a/tests/bitwise_operations/yosys_script.tcl
+++ b/tests/bitwise_operations/yosys_script.tcl
@@ -1,0 +1,6 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/bitwise_operations_reverted_range/Makefile.in
+++ b/tests/bitwise_operations_reverted_range/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/bitwise_operations_reverted_range/main.cpp
+++ b/tests/bitwise_operations_reverted_range/main.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <verilated_vcd_c.h>
+
+#define VL_DEBUG
+#include "Vtop.h"
+#include "verilated.h"
+
+static vluint64_t main_time = 0;
+
+double
+sc_time_stamp()
+{
+  return main_time;
+}
+
+int main (int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Vtop *top = new Vtop();
+
+  Verilated::traceEverOn(true);
+  VerilatedVcdC* tfp = new VerilatedVcdC;
+  top->trace(tfp, 99);
+  tfp->open("dump.vcd");
+
+  while (!Verilated::gotFinish() && (main_time < 100)) {
+    top->eval();
+    tfp->dump(main_time);
+
+    main_time += 1;
+
+    std::cout << "time: " << main_time
+              << " out_1: " << (int)top->out_1
+              << " out_2: " << (int)top->out_2
+              << " out_3: " << (int)top->out_3
+              << " out_4: " << (int)top->out_4
+              << " out_5: " << (int)top->out_5
+              << " out_6: " << (int)top->out_6
+              << " out_7: " << (int)top->out_7
+              << " out_8: " << (int)top->out_8
+              << " out_9: " << (int)top->out_9
+              << " out_10: " << (int)top->out_10
+              << " out_11: " << (int)top->out_11
+              << " out_12: " << (int)top->out_12
+              << " out_13: " << (int)top->out_13
+              << " out_14: " << (int)top->out_14
+              << " out_15: " << (int)top->out_15
+              << " out_16: " << (int)top->out_16
+              << " out_17: " << (int)top->out_17
+              << " out_18: " << (int)top->out_18
+              << std::endl;
+  }
+  top->final();
+  tfp->close();
+  delete top;
+
+  return 0;
+}

--- a/tests/bitwise_operations_reverted_range/top.sv
+++ b/tests/bitwise_operations_reverted_range/top.sv
@@ -1,6 +1,6 @@
 module top
 (
-    input [0:3] in,
+    input [0:3] in, // verilog_lint: waive packed-dimensions-range-ordering
     output out_1, out_2, out_3, out_4, out_5, out_6, out_7, out_8, out_9, out_10,
            out_11, out_12, out_13, out_14, out_15, out_16, out_17, out_18
 );

--- a/tests/bitwise_operations_reverted_range/top.sv
+++ b/tests/bitwise_operations_reverted_range/top.sv
@@ -1,0 +1,27 @@
+module top
+(
+    input [0:3] in,
+    output out_1, out_2, out_3, out_4, out_5, out_6, out_7, out_8, out_9, out_10,
+           out_11, out_12, out_13, out_14, out_15, out_16, out_17, out_18
+);
+    assign out_1 =  in[0] & in[1];
+    assign out_2 =  in[0] | in[1];
+    assign out_3 =  in[0] ~& in[1];
+    assign out_4 =  in[0] ~| in[1];
+    assign out_5 =  in[0] ^ in[1];
+    assign out_6 =  in[0] ~^ in[1];
+    assign out_7 =  in[0] ^~ in[1];
+    assign out_8 =  ~in[0];
+    assign out_9 =  in[0];
+    assign out_10 =  &in[0];
+    assign out_11 =  |in[0];
+    assign out_12 =  ~&in[0];
+    assign out_13 =  ~|in[0];
+    assign out_14 =  ^in[0];
+    assign out_15 =  ~^in[0];
+    assign out_16 =  ^~in[0];
+    assign out_17 =  in[0:1] && in [2:3];
+    assign out_18 =  in[0:1] || in [2:3];
+
+endmodule
+

--- a/tests/bitwise_operations_reverted_range/yosys_script.tcl
+++ b/tests/bitwise_operations_reverted_range/yosys_script.tcl
@@ -1,0 +1,6 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
Test for operations reduction and binary bitwise operations, used for changes done in [PR 394 for chipsalliance/yosys-f4pga-plugins](https://github.com/chipsalliance/yosys-f4pga-plugins/pull/394).