### PR TITLE
add a test with an empty module with type parameter

### DIFF
--- a/tests/TypeParameter/Makefile.in
+++ b/tests/TypeParameter/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/TypeParameter/top.sv
+++ b/tests/TypeParameter/top.sv
@@ -1,0 +1,30 @@
+module prim_sparse_fsm_flop #(
+  parameter type StateEnumT = logic [8:0],
+  parameter int IntParam = 8
+) (
+);
+endmodule
+
+module top();
+  typedef logic state_e;
+
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
+    .IntParam(1)
+  ) u_state_regs (
+  );
+
+  typedef logic [2:0] foo_type;
+
+  prim_sparse_fsm_flop #(
+    .StateEnumT(foo_type)
+  ) u_state_regs2 (
+  );
+
+  prim_sparse_fsm_flop #(
+    .StateEnumT(foo_type)
+  ) u_state_regs3 (
+  );
+
+  prim_sparse_fsm_flop u_state_regs3 ();
+endmodule

--- a/tests/TypeParameter/yosys_script.tcl
+++ b/tests/TypeParameter/yosys_script.tcl
@@ -1,0 +1,5 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv


### PR DESCRIPTION
This can be used to check if the name of a module is mangled properly, considering the values of all parameters.
The parametrized module is deliberately empty as this is just an initial step towards the support of Type Parameters.

New tests:
https://github.com/chipsalliance/UHDM-integration-tests/pull/707

CI running with the new tests:
https://github.com/antmicro/yosys-systemverilog/actions/runs/4253009879