### PR TITLE
Add test for memory inside nested genblocks

### DIFF
--- a/tests/MemoryInGenblock/Makefile.in
+++ b/tests/MemoryInGenblock/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/MemoryInGenblock/top.sv
+++ b/tests/MemoryInGenblock/top.sv
@@ -1,0 +1,34 @@
+module top #(
+  parameter int N   = 8,
+  parameter int DW  = 32
+) (
+  output [DW-1:0] data_i [N]
+);
+  localparam int Instances = 2;
+
+  logic [DW-1:0] mem [N];
+  logic [DW-1:0] data_buf_b [N];
+  logic [DW-1:0] data_buf_c [N];
+
+  for (genvar i = 0; i < Instances; i++) begin : gen_test_a
+    for (genvar j = 0; j < Instances; j++) begin : gen_input_bufs
+      for (genvar k = 0; k < Instances; k++) begin : gen_data_bufs
+        logic [N-1:0] req_buf_a;
+        logic [DW-1:0] data_buf_a [N];
+        if (i == 0 && j == 0 && k ==0) begin : gen_buf
+          assign data_buf_c = data_buf_a;
+        end
+      end
+    end
+  end
+
+  for (genvar i = 0; i < Instances; i++) begin : gen_test_b
+    for (genvar j = 0; j < Instances; j++) begin : gen_input_bufs
+      for (genvar k = 0; k < Instances; k++) begin : gen_data_bufs
+        logic [DW-1:0] data_buf_d [N];
+            assign data_buf_b = mem;
+      end
+    end
+  end
+
+endmodule

--- a/tests/MemoryInGenblock/yosys_script.tcl
+++ b/tests/MemoryInGenblock/yosys_script.tcl
@@ -1,0 +1,3 @@
+source ../yosys_common.tcl
+
+write_verilog -noattr

--- a/tests/ReadmemhInGenblock/Makefile.in
+++ b/tests/ReadmemhInGenblock/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/ReadmemhInGenblock/top.sv
+++ b/tests/ReadmemhInGenblock/top.sv
@@ -1,0 +1,43 @@
+module top #(
+  parameter int N   = 8,
+  parameter int DW  = 32
+) (
+  output [DW-1:0] data_i [N]
+);
+  localparam int Instances = 2;
+
+  logic [DW-1:0] mem [N];
+  logic [DW-1:0] data_buf_b [N];
+  logic [DW-1:0] data_buf_c [N];
+  logic [DW-1:0] data_buf_e [N];
+
+  $readmemh("mem_file.txt", mem);
+
+  for (genvar i = 0; i < Instances; i++) begin : gen_test_a
+    for (genvar j = 0; j < Instances; j++) begin : gen_input_bufs
+      for (genvar k = 0; k < Instances; k++) begin : gen_data_bufs
+        logic [N-1:0] req_buf_a;
+        logic [DW-1:0] data_buf_a [N];
+        if (i == 0 && j == 0 && k ==0) begin : gen_buf
+          assign data_buf_c = data_buf_a;
+        end
+      end
+    end
+  end
+
+  for (genvar i = 0; i < Instances; i++) begin : gen_test_b
+    logic [DW-1:0] data_buf_da [N];
+    for (genvar j = 0; j < Instances; j++) begin : gen_input_bufs
+      logic [DW-1:0] data_buf_db [N];
+      for (genvar k = 0; k < Instances; k++) begin : gen_data_bufs
+        logic [DW-1:0] data_buf_dc [N];
+            $readmemh("mem_file.txt", data_buf_da);
+            $readmemh("mem_file.txt", data_buf_db);
+            $readmemh("mem_file.txt", data_buf_dc);
+            $readmemh("mem_file.txt", data_buf_e);
+            assign data_buf_b = mem;
+      end
+    end
+  end
+
+endmodule

--- a/tests/ReadmemhInGenblock/yosys_script.tcl
+++ b/tests/ReadmemhInGenblock/yosys_script.tcl
@@ -1,0 +1,3 @@
+source ../yosys_common.tcl
+
+write_verilog -noattr


### PR DESCRIPTION
Test for the fix from https://github.com/chipsalliance/yosys-f4pga-plugins/pull/461.
Here is the test workflow from before the fix: https://github.com/antmicro/yosys-systemverilog/actions/runs/4234436714/jobs/7356952841#step:8:1406,
and after the fix: https://github.com/antmicro/yosys-systemverilog/actions/runs/4253333326/jobs/7398326744#step:8:1388.