### PR TITLE
Update yosys tcl scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ uhdm/yosys/test-ast: clean-build surelog/parse
 else
 uhdm/yosys/test-ast: clean-build
 endif
-	(export TOP_FILE="${TOP_FILE}" TOP_MODULE="${TOP_MODULE}" PARSER=${PARSER} && \
+	(export TOP_FILE="${TOP_FILE}" TOP_MODULE="${TOP_MODULE}" PARSER=${PARSER} SURELOG_FLAGS="${SURELOG_FLAGS}" && \
 	cd $(root_dir)/build && ${YOSYS_BIN} -c $(YOSYS_TCL))
 
 # ------------ Test helper targets ------------

--- a/tests/OneImport/yosys_script.tcl
+++ b/tests/OneImport/yosys_script.tcl
@@ -1,22 +1,4 @@
-yosys -import
-plugin -i systemverilog
-yosys -import
-
-if {$::env(PARSER) == "surelog" } {
-	puts "Using Yosys read_uhdm command"
-	read_uhdm -debug dut.uhdm
-} elseif {$::env(PARSER) == "yosys-plugin" } {
-	puts "Using Yosys read_systemverilog command"
-	set files [split $::env(TOP_FILE)]
-	set file0 [ lindex $files 0 ]
-	set file1 [ lindex $files 1 ]
-	read_systemverilog -debug $file0 $file1
-} elseif {$::env(PARSER) == "yosys" } {
-	puts "Using Yosys read_verilog command"
-	read_verilog -debug $::env(TOP_FILE)
-} else {
-	error "Invalid PARSER"
-}
+source ../yosys_common.tcl
 
 #prep -top \\dut
 #write_verilog

--- a/tests/ParameterWithUnderscoreValueDividedPassedFromCommandLine/yosys_script.tcl
+++ b/tests/ParameterWithUnderscoreValueDividedPassedFromCommandLine/yosys_script.tcl
@@ -1,20 +1,4 @@
-yosys -import
-plugin -i systemverilog
-yosys -import
-
-if {$::env(PARSER) == "surelog" } {
-	puts "Using Yosys read_uhdm command"
-	read_uhdm -debug top.uhdm
-} elseif {$::env(PARSER) == "yosys-plugin" } {
-	puts "Using Yosys read_systemverilog command"
-	read_systemverilog -debug -PA=\'d7_200 -PB=\'d1_800 $::env(TOP_FILE)
-} elseif {$::env(PARSER) == "yosys" } {
-	puts "Using Yosys read_verilog command"
-	read_verilog -debug $::env(TOP_FILE)
-} else {
-	error "Invalid PARSER"
-}
-
+source ../yosys_common.tcl
 prep -top \\top
 write_verilog
 write_verilog yosys.sv

--- a/yosys_common.tcl
+++ b/yosys_common.tcl
@@ -7,10 +7,10 @@ if {$::env(PARSER) == "surelog" } {
 	read_uhdm -debug $::env(TOP_MODULE).uhdm
 } elseif {$::env(PARSER) == "yosys-plugin" } {
 	puts "Using Yosys read_systemverilog command"
-	read_systemverilog -debug $::env(TOP_FILE)
+	read_systemverilog -debug -no_dump_ptr $::env(TOP_FILE)
 } elseif {$::env(PARSER) == "yosys" } {
 	puts "Using Yosys read_verilog command"
-	read_verilog -debug $::env(TOP_FILE)
+	read_verilog -sv -debug $::env(TOP_FILE)
 } else {
 	error "Invalid PARSER"
 }

--- a/yosys_common.tcl
+++ b/yosys_common.tcl
@@ -7,7 +7,11 @@ if {$::env(PARSER) == "surelog" } {
 	read_uhdm -debug $::env(TOP_MODULE).uhdm
 } elseif {$::env(PARSER) == "yosys-plugin" } {
 	puts "Using Yosys read_systemverilog command"
-	read_systemverilog -debug -no_dump_ptr $::env(TOP_FILE)
+	if { [info exists ::env(SURELOG_FLAGS)] } {
+		eval read_systemverilog -debug -no_dump_ptr $::env(SURELOG_FLAGS) $::env(TOP_FILE)
+	} else {
+		eval read_systemverilog -debug -no_dump_ptr $::env(TOP_FILE)
+	}
 } elseif {$::env(PARSER) == "yosys" } {
 	puts "Using Yosys read_verilog command"
 	read_verilog -sv -debug $::env(TOP_FILE)


### PR DESCRIPTION
This PR unifies yosys_script.tcl in all tests by calling ``eval`` when environment variable is used to expand it (in case we are using multiple files in ``TOP_FILE `` variable and exports ``SURELOG_FLAGS`` to allow passing additional surelog flags to ``read_systemverilog``.

It also adds ``-sv`` flag to ``read_verilog`` as we probably always want to compare to yosys with systemverilog support enabled and ``-no_dump_ptr`` to ``read_systemverilog`` to disable dumping ptrs.