### PR TITLE
Add test for struct parameter with range, accessed from other module

### DIFF
--- a/tests/TypedefStructParamWithRangeInSubmodule/Makefile.in
+++ b/tests/TypedefStructParamWithRangeInSubmodule/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/TypedefStructParamWithRangeInSubmodule/top.sv
+++ b/tests/TypedefStructParamWithRangeInSubmodule/top.sv
@@ -1,0 +1,29 @@
+package top_pkg; // verilog_lint: waive package-filename
+  parameter MpRegions = 8;
+
+  typedef struct packed {
+    logic [8:0] base;
+    logic [9:0] size;
+  } mp_region_cfg_t;
+
+  typedef struct packed {
+    mp_region_cfg_t [MpRegions:0] region_cfgs;
+  } flash_req_t;
+
+  parameter flash_req_t FLASH_REQ_DEFAULT = '{
+    region_cfgs:   '0
+  };
+endpackage : top_pkg
+
+module flash_ctrl_arb import top_pkg::*; (
+);
+endmodule
+
+module top
+  import top_pkg::*;
+#(
+);
+  flash_ctrl_arb u_ctrl_arb (
+  );
+
+endmodule

--- a/tests/TypedefStructParamWithRangeInSubmodule/yosys_script.tcl
+++ b/tests/TypedefStructParamWithRangeInSubmodule/yosys_script.tcl
@@ -1,0 +1,3 @@
+source ../yosys_common.tcl
+
+write_verilog -noattr


### PR DESCRIPTION
Test for the plugin changes from the PR https://github.com/chipsalliance/yosys-f4pga-plugins/pull/480.

Test yosys-systemverilog CI run after the fix: https://github.com/antmicro/yosys-systemverilog/actions/runs/4629461693
Test yosys-systemverilog CI run before the fix: https://github.com/antmicro/yosys-systemverilog/actions/runs/4629456971