### PR TITLE
Add black-parrot core test

### DIFF
--- a/tests/black-parrot/Makefile.in
+++ b/tests/black-parrot/Makefile.in
@@ -1,0 +1,1 @@
+include $(root_dir)/../uhdm-tests/black-parrot/Makefile.in


### PR DESCRIPTION
This PR adds folder for black-parrot core test. Tool that wants to test this core needs to define its own Makefile.in.