### PR TITLE
Adds list of metadata for verification failures

### DIFF
--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_array_concentrate_static.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_array_concentrate_static.json
@@ -1,0 +1,39 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in dut.v:  1
+
+Mismatch issue: unread points    
+Instances in dut.v:  512
+
+Type BBNet mismatched in Impl (dut.v) at i[240]
+Mismatch issue: compare points    
+Instances in dut.v:  1
+
+Mismatch issue: unread points    
+Instances in dut.v:  512
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+o[0]
+o[100]
+o[101]
+o[102]
+o[103]
+o[104]
+o[105]
+o[106]
+o[107]
+o[108]
+o[109]
+o[110]
+o[111]
+o[112]
+o[113]
+o[114]
+o[115]
+o[116]
+o[117]
+o[118]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_array_concentrate_static.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_array_concentrate_static.json
@@ -7,12 +7,6 @@ Mismatch issue: unread points
 Instances in dut.v:  512
 
 Type BBNet mismatched in Impl (dut.v) at i[240]
-Mismatch issue: compare points    
-Instances in dut.v:  1
-
-Mismatch issue: unread points    
-Instances in dut.v:  512
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_concentrate_static.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_concentrate_static.json
@@ -1,0 +1,31 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in dut.v:  1
+
+Mismatch issue: unread points    
+Instances in dut.v:  32
+
+Type BBNet mismatched in Impl (dut.v) at i[15]
+Mismatch issue: compare points    
+Instances in dut.v:  1
+
+Mismatch issue: unread points    
+Instances in dut.v:  32
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+o[0]
+o[10]
+o[11]
+o[12]
+o[2]
+o[3]
+o[4]
+o[5]
+o[6]
+o[7]
+o[8]
+o[9]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_concentrate_static.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_concentrate_static.json
@@ -7,12 +7,6 @@ Mismatch issue: unread points
 Instances in dut.v:  32
 
 Type BBNet mismatched in Impl (dut.v) at i[15]
-Mismatch issue: compare points    
-Instances in dut.v:  1
-
-Mismatch issue: unread points    
-Instances in dut.v:  32
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fifo_1r1w_narrowed.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fifo_1r1w_narrowed.json
@@ -1,0 +1,23 @@
+****** Matching Report ******
+
+No issues found with matching process!
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+data_o[0]
+data_o[10]
+data_o[11]
+data_o[12]
+data_o[13]
+data_o[14]
+data_o[15]
+data_o[1]
+data_o[2]
+data_o[3]
+data_o[4]
+data_o[5]
+data_o[6]
+data_o[7]
+data_o[8]
+data_o[9]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fifo_1r1w_small_credit_on_input.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fifo_1r1w_small_credit_on_input.json
@@ -4,10 +4,6 @@ Mismatch issue: unread points
 Instances in gold.v: 1
 Instances in dut.v:  1
 
-Mismatch issue: unread points    
-Instances in gold.v: 1
-Instances in dut.v:  1
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fifo_1r1w_small_credit_on_input.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fifo_1r1w_small_credit_on_input.json
@@ -1,0 +1,30 @@
+****** Matching Report ******
+
+Mismatch issue: unread points    
+Instances in gold.v: 1
+Instances in dut.v:  1
+
+Mismatch issue: unread points    
+Instances in gold.v: 1
+Instances in dut.v:  1
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+data_o[0]
+data_o[10]
+data_o[11]
+data_o[12]
+data_o[13]
+data_o[14]
+data_o[15]
+data_o[1]
+data_o[2]
+data_o[3]
+data_o[4]
+data_o[5]
+data_o[6]
+data_o[7]
+data_o[8]
+data_o[9]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb.json
@@ -1,0 +1,210 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in gold.v: 88
+Instances in dut.v:  88
+
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_19_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_20_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_21_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_22_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_23_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_24_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_25_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_26_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_27_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_28_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_29_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_30_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_31_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_19_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_20_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_21_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_22_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_23_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_24_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_25_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_26_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_27_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_28_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_29_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_30_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_31_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_19_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_20_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_21_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_22_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_23_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_24_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_25_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_26_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_27_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_28_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_29_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_30_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_31_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_19_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_20_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_21_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_22_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_23_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_24_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_25_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_26_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_27_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_28_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_29_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_30_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_31_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_2_sv2v_reg_reg
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[10]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[11]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[12]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[13]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[14]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[15]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[3]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[4]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[5]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[6]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[7]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[8]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[9]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[10]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[11]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[12]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[13]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[14]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[15]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[3]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[4]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[5]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[6]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[7]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[8]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[9]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[10]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[11]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[12]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[13]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[14]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[15]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[3]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[4]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[5]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[6]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[7]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[8]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[9]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[10]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[11]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[12]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[13]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[14]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[15]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[3]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[4]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[5]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[6]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[7]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[8]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[0]_reg[9]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Mismatch issue: compare points    
+Instances in gold.v: 88
+Instances in dut.v:  88
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+fsb_node[2].hopin/fifo/empty_r_reg
+fsb_node[3].hopin/fifo/full_r_reg
+fsb_node[4].hopin/fifo/full_r_reg
+fsb_node[1].murn_gateway/genblk1.node_en_r_reg
+fsb_node[2].murn_gateway/genblk1.node_en_r_reg
+fsb_node[3].murn_gateway/genblk1.node_en_r_reg
+fsb_node[4].murn_gateway/genblk1.node_en_r_reg
+fsb_node[2].murn_gateway/genblk1.node_reset_r_reg
+fsb_node[4].murn_gateway/genblk1.node_reset_r_reg
+fsb_node[2].hopin/fifo/head_r_reg
+fsb_node[3].hopin/fifo/head_r_reg
+fsb_node[4].hopin/fifo/head_r_reg
+fsb_node[0].hopin/fifo/mem_1r1w/synth/nz.mem[0]_reg[10]
+fsb_node[0].hopout/fifo/mem_1r1w/synth/nz.mem[0]_reg[10]
+fsb_node[1].hopout/fifo/mem_1r1w/synth/nz.mem[0]_reg[10]
+fsb_node[2].hopout/fifo/mem_1r1w/synth/nz.mem[0]_reg[10]
+fsb_node[3].hopout/fifo/mem_1r1w/synth/nz.mem[0]_reg[10]
+fsb_node[4].hopout/fifo/mem_1r1w/synth/nz.mem[0]_reg[10]
+fsb_node[0].hopin/fifo/mem_1r1w/synth/nz.mem[0]_reg[11]
+fsb_node[0].hopout/fifo/mem_1r1w/synth/nz.mem[0]_reg[11]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb.json
@@ -180,10 +180,6 @@ Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
 Type DFFX mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
 Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
 Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
-Mismatch issue: compare points    
-Instances in gold.v: 88
-Instances in dut.v:  88
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb_murn_gateway.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb_murn_gateway.json
@@ -1,0 +1,14 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in gold.v: 2
+Type DFF mismatched in Ref (gold.v) at node_en_r_o_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at node_reset_r_o_sv2v_reg_reg
+Mismatch issue: compare points    
+Instances in gold.v: 2
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+node_en_r_o
+node_reset_r_o

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb_murn_gateway.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb_murn_gateway.json
@@ -4,8 +4,6 @@ Mismatch issue: compare points
 Instances in gold.v: 2
 Type DFF mismatched in Ref (gold.v) at node_en_r_o_sv2v_reg_reg
 Type DFF mismatched in Ref (gold.v) at node_reset_r_o_sv2v_reg_reg
-Mismatch issue: compare points    
-Instances in gold.v: 2
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb_node_async_buffer.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb_node_async_buffer.json
@@ -56,10 +56,6 @@ Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[1]
 Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[3]
 Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[4]
 Type DFF mismatched in Impl (dut.v) at nz.mem[3]_reg[0]
-Mismatch issue: compare points    
-Instances in gold.v: 26
-Instances in dut.v:  26
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb_node_async_buffer.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_fsb_node_async_buffer.json
@@ -1,0 +1,86 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in gold.v: 26
+Instances in dut.v:  26
+
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_22_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_27_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_32_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_37_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_42_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_47_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_52_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_57_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_62_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_67_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_72_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_77_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_22_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_27_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_32_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_37_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_42_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_47_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_52_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_57_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_62_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_67_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_72_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at nz.mem_77_sv2v_reg_reg
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[3]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[4]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[3]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[4]
+Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[3]
+Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[4]
+Type DFF mismatched in Impl (dut.v) at nz.mem[3]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[3]
+Type DFF mismatched in Impl (dut.v) at nz.mem[0]_reg[4]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[3]
+Type DFF mismatched in Impl (dut.v) at nz.mem[1]_reg[4]
+Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[0]
+Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[1]
+Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[3]
+Type DFF mismatched in Impl (dut.v) at nz.mem[2]_reg[4]
+Type DFF mismatched in Impl (dut.v) at nz.mem[3]_reg[0]
+Mismatch issue: compare points    
+Instances in gold.v: 26
+Instances in dut.v:  26
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[0]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[10]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[11]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[12]_reg[2]
+r2l_fifo/MSYNC_1r1w/synth/nz.mem[12]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[13]_reg[2]
+r2l_fifo/MSYNC_1r1w/synth/nz.mem[13]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[14]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[15]_reg[2]
+r2l_fifo/MSYNC_1r1w/synth/nz.mem[15]_reg[2]
+r2l_fifo/MSYNC_1r1w/synth/nz.mem[1]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[2]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[4]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[6]_reg[2]
+r2l_fifo/MSYNC_1r1w/synth/nz.mem[6]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[7]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[8]_reg[2]
+r2l_fifo/MSYNC_1r1w/synth/nz.mem[8]_reg[2]
+l2r_fifo/MSYNC_1r1w/synth/nz.mem[9]_reg[2]
+r2l_fifo/MSYNC_1r1w/synth/nz.mem[9]_reg[2]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_hash_bank.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_hash_bank.json
@@ -1,0 +1,16 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in gold.v: 1
+Instances in dut.v:  1
+
+Type Port mismatched in Ref (gold.v) at bank_o[0]
+Type Port mismatched in Impl (dut.v) at bank_o
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+
+**** Verification Report ****
+
+Non-Equivalent Points:

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_imul_iterative.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_imul_iterative.json
@@ -159,10 +159,6 @@ Type DFF mismatched in Impl (dut.v) at shift_counter_r_reg[4]
 Type DFF mismatched in Impl (dut.v) at shift_counter_r_reg[5]
 Type DFF mismatched in Impl (dut.v) at signed_opA_r_reg
 Type DFF mismatched in Impl (dut.v) at signed_opB_r_reg
-Mismatch issue: compare points    
-Instances in gold.v: 76
-Instances in dut.v:  79
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_imul_iterative.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_imul_iterative.json
@@ -1,0 +1,189 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in gold.v: 76
+Instances in dut.v:  79
+
+Type DFF mismatched in Ref (gold.v) at all_sh_lsb_zero_r_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at curr_state_r_0_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at curr_state_r_1_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at gets_high_part_r_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_0_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_10_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_11_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_12_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_13_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_14_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_15_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_19_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_1_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_20_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_21_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_22_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_23_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_24_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_25_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_26_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_27_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_28_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_29_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_30_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_31_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_3_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_4_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_5_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_6_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_7_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_8_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opA_r_9_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_0_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_10_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_11_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_12_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_13_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_14_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_15_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_16_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_17_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_18_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_19_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_1_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_20_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_21_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_22_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_23_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_24_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_25_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_26_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_27_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_28_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_29_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_30_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_31_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_3_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_4_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_5_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_6_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_7_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_8_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at opB_r_9_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at shift_counter_r_0_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at shift_counter_r_1_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at shift_counter_r_2_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at shift_counter_r_3_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at shift_counter_r_4_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at shift_counter_r_5_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at signed_opA_r_sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at signed_opB_r_sv2v_reg_reg
+Type DFF mismatched in Impl (dut.v) at all_sh_lsb_zero_r_reg
+Type DFF mismatched in Impl (dut.v) at curr_state_r_reg[0]
+Type DFF mismatched in Impl (dut.v) at curr_state_r_reg[2]
+Type DFF mismatched in Impl (dut.v) at curr_state_r_reg[3]
+Type DFF mismatched in Impl (dut.v) at curr_state_r_reg[4]
+Type DFF mismatched in Impl (dut.v) at gets_high_part_r_reg
+Type DFF mismatched in Impl (dut.v) at need_neg_result_r_reg
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[0]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[10]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[11]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[12]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[13]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[14]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[15]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[16]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[17]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[18]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[19]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[1]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[20]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[21]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[22]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[23]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[24]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[25]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[26]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[27]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[28]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[29]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[2]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[30]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[31]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[3]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[4]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[5]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[6]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[7]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[8]
+Type DFF mismatched in Impl (dut.v) at opA_r_reg[9]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[0]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[10]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[11]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[12]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[13]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[14]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[15]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[16]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[17]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[18]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[19]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[1]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[20]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[21]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[22]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[23]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[24]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[25]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[26]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[27]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[28]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[29]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[2]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[30]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[31]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[3]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[4]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[5]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[6]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[7]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[8]
+Type DFF mismatched in Impl (dut.v) at opB_r_reg[9]
+Type DFF mismatched in Impl (dut.v) at shift_counter_r_reg[0]
+Type DFF mismatched in Impl (dut.v) at shift_counter_r_reg[1]
+Type DFF mismatched in Impl (dut.v) at shift_counter_r_reg[2]
+Type DFF mismatched in Impl (dut.v) at shift_counter_r_reg[3]
+Type DFF mismatched in Impl (dut.v) at shift_counter_r_reg[4]
+Type DFF mismatched in Impl (dut.v) at shift_counter_r_reg[5]
+Type DFF mismatched in Impl (dut.v) at signed_opA_r_reg
+Type DFF mismatched in Impl (dut.v) at signed_opB_r_reg
+Mismatch issue: compare points    
+Instances in gold.v: 76
+Instances in dut.v:  79
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+curr_state_r_reg[5]
+result_r_reg[0]
+result_r_reg[10]
+result_r_reg[11]
+result_r_reg[12]
+result_r_reg[13]
+result_r_reg[14]
+result_r_reg[15]
+result_r_reg[16]
+result_r_reg[17]
+result_r_reg[18]
+result_r_reg[19]
+result_r_reg[1]
+result_r_reg[20]
+result_r_reg[21]
+result_r_reg[22]
+result_r_reg[23]
+result_r_reg[24]
+result_r_reg[25]
+result_r_reg[26]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_mul_array_row.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_mul_array_row.json
@@ -1,0 +1,12 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in gold.v: 1
+Type DFF mismatched in Ref (gold.v) at prod_accum_o_15_sv2v_reg_reg
+Mismatch issue: compare points    
+Instances in gold.v: 1
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+prod_accum_o[15]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_mul_array_row.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_mul_array_row.json
@@ -3,8 +3,6 @@
 Mismatch issue: compare points    
 Instances in gold.v: 1
 Type DFF mismatched in Ref (gold.v) at prod_accum_o_15_sv2v_reg_reg
-Mismatch issue: compare points    
-Instances in gold.v: 1
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_parallel_in_serial_out_dynamic.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_parallel_in_serial_out_dynamic.json
@@ -1,0 +1,23 @@
+****** Matching Report ******
+
+No issues found with matching process!
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+data_o[0]
+data_o[10]
+data_o[11]
+data_o[12]
+data_o[13]
+data_o[14]
+data_o[15]
+data_o[1]
+data_o[2]
+data_o[3]
+data_o[4]
+data_o[5]
+data_o[6]
+data_o[7]
+data_o[8]
+data_o[9]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_permute_box.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_permute_box.json
@@ -3,9 +3,6 @@
 Mismatch issue: unread points    
 Instances in dut.v:  32
 
-Mismatch issue: unread points    
-Instances in dut.v:  32
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_permute_box.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_permute_box.json
@@ -1,0 +1,28 @@
+****** Matching Report ******
+
+Mismatch issue: unread points    
+Instances in dut.v:  32
+
+Mismatch issue: unread points    
+Instances in dut.v:  32
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+data_o[0]
+data_o[10]
+data_o[11]
+data_o[12]
+data_o[13]
+data_o[14]
+data_o[15]
+data_o[1]
+data_o[2]
+data_o[3]
+data_o[4]
+data_o[5]
+data_o[6]
+data_o[7]
+data_o[8]
+data_o[9]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_reduce_segmented.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_reduce_segmented.json
@@ -1,0 +1,16 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in gold.v: 1
+Instances in dut.v:  1
+
+Type Port mismatched in Ref (gold.v) at o[0]
+Type Port mismatched in Impl (dut.v) at o
+Mismatch issue: compare points    
+Instances in gold.v: 1
+Instances in dut.v:  1
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_reduce_segmented.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_reduce_segmented.json
@@ -6,10 +6,6 @@ Instances in dut.v:  1
 
 Type Port mismatched in Ref (gold.v) at o[0]
 Type Port mismatched in Impl (dut.v) at o
-Mismatch issue: compare points    
-Instances in gold.v: 1
-Instances in dut.v:  1
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_round_robin_n_to_1.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_round_robin_n_to_1.json
@@ -1,0 +1,16 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in gold.v: 1
+Instances in dut.v:  1
+
+Type Port mismatched in Ref (gold.v) at tag_o[0]
+Type Port mismatched in Impl (dut.v) at tag_o
+Mismatch issue: compare points    
+Instances in gold.v: 1
+Instances in dut.v:  1
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_round_robin_n_to_1.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_round_robin_n_to_1.json
@@ -6,10 +6,6 @@ Instances in dut.v:  1
 
 Type Port mismatched in Ref (gold.v) at tag_o[0]
 Type Port mismatched in Impl (dut.v) at tag_o
-Mismatch issue: compare points    
-Instances in gold.v: 1
-Instances in dut.v:  1
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_sbox.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_sbox.json
@@ -1,0 +1,38 @@
+****** Matching Report ******
+
+Mismatch issue: compare points    
+Instances in gold.v: 2
+Instances in dut.v:  2
+
+Type DFF mismatched in Ref (gold.v) at sbox_1_.fi1hot.fwd_sel_one_hot_r_1__0__sv2v_reg_reg
+Type DFF mismatched in Ref (gold.v) at sbox_2_.fi1hot.fwd_sel_one_hot_r_2__0__sv2v_reg_reg
+Type DFF0X mismatched in Impl (dut.v) at sbox_reg[1].fi1hot.fwd_sel_one_hot_r[4]_reg
+Type DFF0X mismatched in Impl (dut.v) at sbox_reg[2].fi1hot.fwd_sel_one_hot_r[8]_reg
+Mismatch issue: compare points    
+Instances in gold.v: 2
+Instances in dut.v:  2
+
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+in_data_o[16]
+in_data_o[17]
+in_data_o[18]
+in_data_o[19]
+in_data_o[20]
+in_data_o[21]
+in_data_o[22]
+in_data_o[23]
+in_data_o[24]
+in_data_o[25]
+in_data_o[26]
+in_data_o[27]
+in_data_o[28]
+in_data_o[29]
+in_data_o[30]
+in_data_o[31]
+in_v_o[1]
+in_v_o[2]
+out_me_data_o[32]
+out_me_data_o[33]

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_sbox.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_sbox.json
@@ -8,10 +8,6 @@ Type DFF mismatched in Ref (gold.v) at sbox_1_.fi1hot.fwd_sel_one_hot_r_1__0__sv
 Type DFF mismatched in Ref (gold.v) at sbox_2_.fi1hot.fwd_sel_one_hot_r_2__0__sv2v_reg_reg
 Type DFF0X mismatched in Impl (dut.v) at sbox_reg[1].fi1hot.fwd_sel_one_hot_r[4]_reg
 Type DFF0X mismatched in Impl (dut.v) at sbox_reg[2].fi1hot.fwd_sel_one_hot_r[8]_reg
-Mismatch issue: compare points    
-Instances in gold.v: 2
-Instances in dut.v:  2
-
 
 **** Verification Report ****
 

--- a/tests/bsg/bsg_micro_designs_results/issue_list/bsg_wait_cycles.json
+++ b/tests/bsg/bsg_micro_designs_results/issue_list/bsg_wait_cycles.json
@@ -1,0 +1,8 @@
+****** Matching Report ******
+
+No issues found with matching process!
+
+**** Verification Report ****
+
+Non-Equivalent Points:
+ctr_r_reg[4]


### PR DESCRIPTION
Each set of dut.v and gold.v in `tests/bsg/bsg_micro_designs_results` that did not pass verification is provided with a small metadata file detailing some select information regarding its reasons for failure.

Matching Results dictates the section of verification dedicated to matching the ports together between the two instances, whereas Verification Results dictates the section that determines the logical equivalence of compare points.

If a Verification Results section is empty but there is still a provided file, that means that the failure was due to a mismatched set of ports and the design could not be verified. Fixing it at the matching level is likely to fix these issues.

A table of the different types of compare points is given here:
  BBNet: multiply-driven net
  BBox:  black-box
  BBPin: black-box pin
  Block: hierarchical block
  BlPin: hierarchical block pin
  Cut:   cut-point
  DFF:   non-constant DFF register
  DFF0:  constant 0 DFF register
  DFF1:  constant 1 DFF register
  DFFX:  constant X DFF register
  DFF0X: constrained 0X DFF register
  DFF1X: constrained 1X DFF register
  LAT:   non-constant latch register
  LAT0:  constant 0 latch register
  LAT1:  constant 1 latch register
  LATX:  constant X latch register
  LAT0X: constrained 0X latch register
  LAT1X: constrained 1X latch register
  LATCG: clock-gating latch register
  TLA:   transparent latch register
  TLA0X: transparent constrained 0X latch register
  TLA1X: transparent constrained 1X latch register
  Loop:  cycle break point
  Net:   matchable net
  Port:  primary (top-level) port
  Und:   undriven signal cut-point
  Unk:   unknown signal cut-point