### PR TITLE
Import yosys commands once.

### DIFF
--- a/yosys_common.tcl
+++ b/yosys_common.tcl
@@ -1,5 +1,4 @@
-yosys -import
-plugin -i systemverilog
+yosys plugin -i systemverilog
 yosys -import
 
 if {$::env(PARSER) == "surelog" } {


### PR DESCRIPTION
Removes a long list of warnings about pre-existing command from output of every test. The warnings look like this one:

```
Command name collision: found pre-existing command `cd' -> skip.
```