### PR TITLE
Add -elabuhdm to parse surelog task and a new test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 
 surelog/parse: clean-build
 	(cd ${root_dir}/build && \
-		${SURELOG_BIN} -parse -sverilog -d coveruhdm ${SURELOG_FLAGS} $(INCLUDE) $(TOP_FILE))
+		${SURELOG_BIN} -parse -sverilog -d coveruhdm -elabuhdm ${SURELOG_FLAGS} $(INCLUDE) $(TOP_FILE))
 	cp ${root_dir}/build/slpp_all/surelog.uhdm ${TOP_UHDM}
 
 uhdm/yosys/verilate-ast:

--- a/tests/ImportedFunctionCallAsInstantiatedModulePortValueInsideGenFor/Makefile.in
+++ b/tests/ImportedFunctionCallAsInstantiatedModulePortValueInsideGenFor/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/ImportedFunctionCallAsInstantiatedModulePortValueInsideGenFor/top.sv
+++ b/tests/ImportedFunctionCallAsInstantiatedModulePortValueInsideGenFor/top.sv
@@ -1,0 +1,21 @@
+package some_package; // verilog_lint: waive package-filename
+  function automatic logic the_function_name(logic val);
+    return val == 1;
+  endfunction : the_function_name
+endpackage : some_package
+
+module module_name (input logic module_input);
+endmodule
+
+module top
+  import some_package::*;
+();
+  logic some_wire;
+
+  for (genvar k = 0; k < 2; k++) begin : gen_for_generate_loop_name
+    module_name an_instance (
+      .module_input(the_function_name(some_wire))
+    );
+  end
+
+endmodule : top

--- a/tests/ImportedFunctionCallAsInstantiatedModulePortValueInsideGenFor/yosys_script.tcl
+++ b/tests/ImportedFunctionCallAsInstantiatedModulePortValueInsideGenFor/yosys_script.tcl
@@ -1,0 +1,1 @@
+source ../yosys_common.tcl

--- a/tests/SizeOfGeneratedWireArray/top.sv
+++ b/tests/SizeOfGeneratedWireArray/top.sv
@@ -6,5 +6,5 @@ module top(output int o);
       end
    endgenerate
 
-   assign o = $bits(blk[0].z);
+   assign o = $bits(gen_blk[0].z);
 endmodule


### PR DESCRIPTION
This PR adds ``-elabuhdm`` to surelog parsing task. Now Surelog requires ``-elabuhdm`` for constant evaluation: https://github.com/chipsalliance/Surelog/issues/3713#issuecomment-1595938365

Also adds a new test.

These changes are intended to work after merge of https://github.com/chipsalliance/yosys-f4pga-plugins/pull/531.

yosys-systemverilog CI: https://github.com/antmicro/yosys-systemverilog/actions/runs/5798599424